### PR TITLE
Add Windows guest OpenGL/OpenCL/Vulkan via D3D mapping layers

### DIFF
--- a/AppSandbox.sln
+++ b/AppSandbox.sln
@@ -8,6 +8,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AppSandbox", "AppSandbox.vc
 	ProjectSection(ProjectDependencies) = postProject
 		{1A2B3C4D-5E6F-7890-ABCD-111222333444} = {1A2B3C4D-5E6F-7890-ABCD-111222333444}
 		{D4E5F6A7-B8C9-0123-4567-89ABCDEF0123} = {D4E5F6A7-B8C9-0123-4567-89ABCDEF0123}
+		{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F} = {C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "agent", "tools\agent\agent.vcxproj", "{D4E5F6A7-B8C9-0123-4567-89ABCDEF0123}"
@@ -31,6 +32,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "appsandbox-clipboard-reader", "tools\agent\appsandbox-clipboard-reader.vcxproj", "{D4E5F6A7-B8C9-0123-CDEF-456789012345}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "appsandbox-audio", "tools\agent\appsandbox-audio.vcxproj", "{E5F6A7B8-C9D0-1234-EF01-567890123456}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "appsandbox_gl_shim", "tools\gl-shim\appsandbox_gl_shim.vcxproj", "{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -144,6 +147,14 @@ Global
 		{E5F6A7B8-C9D0-1234-EF01-567890123456}.Release|ARM64.Build.0 = Release|ARM64
 		{E5F6A7B8-C9D0-1234-EF01-567890123456}.Release|x64.ActiveCfg = Release|x64
 		{E5F6A7B8-C9D0-1234-EF01-567890123456}.Release|x64.Build.0 = Release|x64
+		{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}.Debug|ARM64.Build.0 = Debug|ARM64
+		{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}.Debug|x64.ActiveCfg = Debug|x64
+		{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}.Debug|x64.Build.0 = Debug|x64
+		{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}.Release|ARM64.ActiveCfg = Release|ARM64
+		{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}.Release|ARM64.Build.0 = Release|ARM64
+		{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}.Release|x64.ActiveCfg = Release|x64
+		{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AppSandboxCore.vcxproj
+++ b/AppSandboxCore.vcxproj
@@ -173,6 +173,7 @@
     <ClCompile Include="src\backend_win\hcn_network.c" />
     <ClCompile Include="src\backend_win\gpu_enum.c" />
     <ClCompile Include="src\backend_win\disk_util.c" />
+    <ClCompile Include="src\backend_win\d3dlayers.c" />
     <ClCompile Include="src\backend_win\snapshot.c" />
     <ClCompile Include="src\backend_win\vmms_cert.c" />
     <ClCompile Include="src\backend_win\vm_agent.c" />
@@ -189,6 +190,8 @@
     <ClInclude Include="src\backend_win\hcn_network.h" />
     <ClInclude Include="src\backend_win\gpu_enum.h" />
     <ClInclude Include="src\backend_win\disk_util.h" />
+    <ClInclude Include="src\backend_win\d3dlayers.h" />
+    <ClInclude Include="src\backend_win\fe3_templates.h" />
     <ClInclude Include="src\backend_win\snapshot.h" />
     <ClInclude Include="src\backend_win\vmms_cert.h" />
     <ClInclude Include="src\backend_win\vm_agent.h" />

--- a/src/backend_win/asb_core.c
+++ b/src/backend_win/asb_core.c
@@ -12,6 +12,7 @@
 #include "gpu_enum.h"
 #include "hcn_network.h"
 #include "disk_util.h"
+#include "d3dlayers.h"
 #include "snapshot.h"
 #include "vmms_cert.h"
 #include "vm_agent.h"
@@ -46,6 +47,33 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 /* ---- Globals ---- */
 
 static GpuList g_gpu_list;
+
+/* Prepare the GL mapping-layer Plan9 share for a Windows GPU guest: ensure the
+ * D3D mapping layers are fetched/cached on the host, place the OpenGL ICD shim
+ * alongside them, then append the "AppSandbox.GlLayers" share. The guest agent
+ * copies this share AFTER the GPU driver shares and provisions it (stages
+ * dxil.dll to System32, sets AppInit_DLLs + the Khronos OpenCL/Vulkan ICD keys).
+ * Best-effort: if the layers can't be fetched, no share is added and GL/CL/
+ * Vulkan acceleration is simply unavailable. */
+static void prepare_gl_layers_share(GpuDriverShareList *shares)
+{
+    wchar_t dir[MAX_PATH], exe[MAX_PATH], src[MAX_PATH], dst[MAX_PATH], *slash;
+
+    if (!d3dlayers_ensure_cached(dir, MAX_PATH))
+        return;
+
+    /* Stage the OpenGL ICD shim into the same dir so one share carries it. */
+    GetModuleFileNameW(NULL, exe, MAX_PATH);
+    slash = wcsrchr(exe, L'\\');
+    if (slash) *slash = L'\0';
+    swprintf_s(src, MAX_PATH, L"%s\\resources\\appsandbox_gl_shim.dll", exe);
+    if (GetFileAttributesW(src) == INVALID_FILE_ATTRIBUTES)
+        swprintf_s(src, MAX_PATH, L"%s\\appsandbox_gl_shim.dll", exe);
+    swprintf_s(dst, MAX_PATH, L"%s\\appsandbox_gl_shim.dll", dir);
+    CopyFileW(src, dst, FALSE);  /* best-effort; shim may not be built yet */
+
+    gpu_append_gl_layers_share(shares, dir);
+}
 
 static VmInstance g_vms[ASB_MAX_VMS];
 static int g_vm_count = 0;
@@ -862,6 +890,8 @@ static DWORD WINAPI start_vm_thread(LPVOID param)
          * per-GPU driver shares. Windows guests have no use for it. */
         if (_wcsicmp(args->config.os_type, L"Linux") == 0)
             gpu_append_lxsslib_share(&args->config.gpu_shares);
+        else if (_wcsicmp(args->config.os_type, L"Windows") == 0)
+            prepare_gl_layers_share(&args->config.gpu_shares);
     }
 
     asb_log(L"Re-creating HCS compute system for \"%s\"...", vm->name);
@@ -2598,6 +2628,8 @@ ASB_API HRESULT asb_vm_create(const AsbVmConfig *config)
          * /usr/lib/wsl/lib by the agent on first connect. */
         if (_wcsicmp(cfg.os_type, L"Linux") == 0)
             gpu_append_lxsslib_share(&cfg.gpu_shares);
+        else if (_wcsicmp(cfg.os_type, L"Windows") == 0)
+            prepare_gl_layers_share(&cfg.gpu_shares);
     }
 
     /* ---- VHDX-first path (Windows, from ISO) ---- */

--- a/src/backend_win/d3dlayers.c
+++ b/src/backend_win/d3dlayers.c
@@ -1,0 +1,611 @@
+/*
+ * d3dlayers.c -- see d3dlayers.h.
+ *
+ * Pipeline (all on the host; mirrors tools/iso-patch/prefetch_repo.c idioms):
+ *   1. GET displaycatalog.mp.microsoft.com for product 9NQPSL29BFFF
+ *      -> parse the package's WuCategoryId (resolved live, never hardcoded).
+ *   2. Windows Update FE3 client protocol over WinHTTP (HTTPS):
+ *        GetCookie -> SyncUpdates(filtered by WuCategoryId)
+ *                  -> GetExtendedUpdateInfo2 -> time-limited CDN url.
+ *      The x64 package is located by identifier in the response, so version
+ *      changes / extra updates do not break resolution.
+ *   3. Download the .appx (a zip) from the Microsoft CDN.
+ *   4. Extract with the in-box tar.exe (libarchive handles zip natively).
+ *   5. Copy the mapping-layer files into <exe_dir>\d3dlayers\ (cached).
+ *
+ * Defensive throughout: any failure returns FALSE and VM creation continues
+ * without GL/CL/Vulkan acceleration.
+ */
+
+#include "d3dlayers.h"
+#include "fe3_templates.h"
+#include "ui.h"
+
+#include <winhttp.h>
+#include <rpc.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#pragma comment(lib, "winhttp.lib")
+#pragma comment(lib, "rpcrt4.lib")
+
+#define DL_PRODUCT_ID       L"9NQPSL29BFFF"
+#define DL_FE3_HOST         L"fe3.delivery.mp.microsoft.com"
+#define DL_FE3_PATH         L"/ClientWebService/client.asmx"
+#define DL_FE3_PATH_SECURED L"/ClientWebService/client.asmx/secured"
+#define DL_SOAP_HEADERS     L"Content-Type: application/soap+xml; charset=utf-8\r\n"
+#define DL_CACHE_SUBDIR     L"d3dlayers"
+#define DL_APPX_NAME        L"D3DMappingLayers_x64.appx"
+#define DL_MAX_ROUNDS       5   /* FE3 faults intermittently; retry the chain */
+
+/* Files to extract: dest leaf name <- source path inside the .appx. */
+static const wchar_t *const DL_DST[] = {
+    L"OpenGLOn12.dll", L"dxil.dll", L"OpenCLOn12.dll",
+    L"clon12compiler.dll", L"vulkan_dzn.dll", L"dzn_icd.x64.json"
+};
+static const wchar_t *const DL_SRC[] = {
+    L"x64\\OpenGLOn12.dll", L"x64\\dxil.dll", L"x64\\OpenCLOn12.dll",
+    L"x64\\clon12compiler.dll", L"x64\\vulkan_dzn.dll", L"dzn_icd.x64.json"
+};
+#define DL_NFILES ((int)(sizeof(DL_DST)/sizeof(DL_DST[0])))
+
+/* ---- small helpers (local; backend_win has no shared util header) ---- */
+
+static void get_exe_dir(wchar_t *out, size_t cch)
+{
+    wchar_t *slash;
+    GetModuleFileNameW(NULL, out, (DWORD)cch);
+    slash = wcsrchr(out, L'\\');
+    if (slash) *slash = L'\0';
+}
+
+static void mkdir_p(const wchar_t *path)
+{
+    wchar_t buf[MAX_PATH];
+    wchar_t *p;
+    wcsncpy_s(buf, MAX_PATH, path, _TRUNCATE);
+    p = buf;
+    if (wcslen(buf) >= 3 && buf[1] == L':' && buf[2] == L'\\') p = buf + 3;
+    for (; *p; p++) {
+        if (*p == L'\\') { *p = 0; CreateDirectoryW(buf, NULL); *p = L'\\'; }
+    }
+    CreateDirectoryW(buf, NULL);
+}
+
+static int run_hidden(const wchar_t *cmdline)
+{
+    wchar_t mut[2048];
+    STARTUPINFOW si = { sizeof(si) };
+    PROCESS_INFORMATION pi = { 0 };
+    DWORD ec = 1;
+    wcsncpy_s(mut, 2048, cmdline, _TRUNCATE);
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+    if (!CreateProcessW(NULL, mut, NULL, NULL, FALSE, CREATE_NO_WINDOW,
+                        NULL, NULL, &si, &pi)) {
+        ui_log(L"d3dlayers: CreateProcess failed: %lu", GetLastError());
+        return -1;
+    }
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    GetExitCodeProcess(pi.hProcess, &ec);
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    return (int)ec;
+}
+
+static BOOL file_exists(const wchar_t *path)
+{
+    return GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES;
+}
+
+/* Fresh lowercase UUID (no braces) for the WS-Addressing MessageID. FE3
+ * rejects replayed message IDs, so every request must use a new one. */
+static void new_guid(char *out, size_t cch)
+{
+    UUID u;
+    RPC_CSTR s = NULL;
+    out[0] = 0;
+    if (UuidCreate(&u) != RPC_S_OK && UuidCreateSequential(&u) != RPC_S_OK) return;
+    if (UuidToStringA(&u, &s) == RPC_S_OK && s) {
+        strncpy_s(out, cch, (const char *)s, _TRUNCATE);
+        RpcStringFreeA(&s);
+    }
+}
+
+/* WS-Security timestamps: created = now (UTC), expires = now + 5 minutes. */
+static void iso_times(char *created, size_t ccch, char *expires, size_t ecch)
+{
+    SYSTEMTIME st, ex;
+    FILETIME ft;
+    ULARGE_INTEGER q;
+    GetSystemTime(&st);
+    sprintf_s(created, ccch, "%04u-%02u-%02uT%02u:%02u:%02u.%03uZ",
+              st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond, st.wMilliseconds);
+    SystemTimeToFileTime(&st, &ft);
+    q.LowPart = ft.dwLowDateTime; q.HighPart = ft.dwHighDateTime;
+    q.QuadPart += (ULONGLONG)5 * 60 * 10000000ULL;
+    ft.dwLowDateTime = q.LowPart; ft.dwHighDateTime = q.HighPart;
+    FileTimeToSystemTime(&ft, &ex);
+    sprintf_s(expires, ecch, "%04u-%02u-%02uT%02u:%02u:%02u.%03uZ",
+              ex.wYear, ex.wMonth, ex.wDay, ex.wHour, ex.wMinute, ex.wSecond, ex.wMilliseconds);
+}
+
+/* Allocate a copy of src with every occurrence of tok replaced by val. */
+static char *str_replace_all(const char *src, const char *tok, const char *val)
+{
+    size_t tl = strlen(tok), vl = strlen(val), cnt = 0;
+    const char *p = src, *s;
+    char *out, *d;
+    while ((p = strstr(p, tok)) != NULL) { cnt++; p += tl; }
+    out = (char *)malloc(strlen(src) + cnt * vl + 1);
+    if (!out) return NULL;
+    d = out; s = src;
+    while (*s) {
+        if (strncmp(s, tok, tl) == 0) { memcpy(d, val, vl); d += vl; s += tl; }
+        else { *d++ = *s++; }
+    }
+    *d = 0;
+    return out;
+}
+
+/* In-place minimal XML entity decode (FE3 escapes the inner update XML once). */
+static void html_unescape(char *s)
+{
+    char *d = s, *p = s;
+    while (*p) {
+        if (*p == '&') {
+            if (!strncmp(p, "&lt;", 4))        { *d++ = '<';  p += 4; continue; }
+            if (!strncmp(p, "&gt;", 4))        { *d++ = '>';  p += 4; continue; }
+            if (!strncmp(p, "&quot;", 6))      { *d++ = '"';  p += 6; continue; }
+            if (!strncmp(p, "&apos;", 6))      { *d++ = '\''; p += 6; continue; }
+            if (!strncmp(p, "&#39;", 5))       { *d++ = '\''; p += 5; continue; }
+            if (!strncmp(p, "&amp;", 5))       { *d++ = '&';  p += 5; continue; }
+        }
+        *d++ = *p++;
+    }
+    *d = 0;
+}
+
+/* Copy text between a and b (after a, before next b) into out. */
+static BOOL between(const char *buf, const char *a, const char *b, char *out, size_t cch)
+{
+    const char *p = strstr(buf, a), *q;
+    size_t n;
+    if (!p) return FALSE;
+    p += strlen(a);
+    q = strstr(p, b);
+    if (!q) return FALSE;
+    n = (size_t)(q - p);
+    if (n >= cch) n = cch - 1;
+    memcpy(out, p, n);
+    out[n] = 0;
+    return TRUE;
+}
+
+/* Read an XML attribute value (attr="...") from a bounded tag string. */
+static BOOL attr_in(const char *tag, const char *attr, char *out, size_t cch)
+{
+    char needle[64];
+    sprintf_s(needle, sizeof(needle), "%s=\"", attr);
+    return between(tag, needle, "\"", out, cch);
+}
+
+/* Last occurrence of needle in buf[0..limit). */
+static const char *rfind(const char *buf, const char *limit, const char *needle)
+{
+    const char *best = NULL, *p = buf;
+    size_t nl = strlen(needle);
+    while ((p = strstr(p, needle)) != NULL && p < limit) { best = p; p += nl; }
+    return best;
+}
+
+/* ---- WinHTTP ---- */
+
+/* Perform a request; return the response body as a heap buffer (NUL-terminated)
+ * regardless of HTTP status (SOAP faults carry a body we may inspect). Caller
+ * frees. Returns NULL only on transport failure. */
+static char *http_body(BOOL secure, const wchar_t *host, INTERNET_PORT port,
+                       const wchar_t *verb, const wchar_t *path,
+                       const wchar_t *headers, const void *body, DWORD body_len)
+{
+    HINTERNET hS = NULL, hC = NULL, hR = NULL;
+    char *resp = NULL;
+    DWORD cap = 0, used = 0;
+
+    hS = WinHttpOpen(L"AppSandbox/1.0", WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
+                     WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (!hS) goto done;
+    hC = WinHttpConnect(hS, host, port, 0);
+    if (!hC) goto done;
+    hR = WinHttpOpenRequest(hC, verb, path, NULL, WINHTTP_NO_REFERER,
+                            WINHTTP_DEFAULT_ACCEPT_TYPES,
+                            secure ? WINHTTP_FLAG_SECURE : 0);
+    if (!hR) goto done;
+    if (!WinHttpSendRequest(hR, headers ? headers : WINHTTP_NO_ADDITIONAL_HEADERS,
+                            headers ? (DWORD)-1L : 0,
+                            (LPVOID)body, body_len, body_len, 0)) goto done;
+    if (!WinHttpReceiveResponse(hR, NULL)) goto done;
+
+    for (;;) {
+        DWORD avail = 0, rd = 0;
+        if (!WinHttpQueryDataAvailable(hR, &avail)) break;
+        if (avail == 0) break;
+        if (used + avail + 1 > cap) {
+            DWORD nc = (used + avail + 1) * 2;
+            char *n = (char *)realloc(resp, nc);
+            if (!n) { free(resp); resp = NULL; goto done; }
+            resp = n; cap = nc;
+        }
+        if (!WinHttpReadData(hR, resp + used, avail, &rd)) break;
+        if (rd == 0) break;
+        used += rd;
+    }
+    if (resp) resp[used] = 0;
+
+done:
+    if (hR) WinHttpCloseHandle(hR);
+    if (hC) WinHttpCloseHandle(hC);
+    if (hS) WinHttpCloseHandle(hS);
+    return resp;
+}
+
+/* POST a SOAP envelope (UTF-8) to the FE3 service; returns the response body. */
+static char *fe3_post(const wchar_t *path, const char *envelope)
+{
+    return http_body(TRUE, DL_FE3_HOST, INTERNET_DEFAULT_HTTPS_PORT, L"POST",
+                     path, DL_SOAP_HEADERS, envelope, (DWORD)strlen(envelope));
+}
+
+/* GET a full URL and stream it to a file. Handles http/https and query string. */
+static int http_download(const wchar_t *url, const wchar_t *out_path)
+{
+    URL_COMPONENTS uc;
+    wchar_t host[256], upath[4096], extra[2048], fullpath[6144];
+    HINTERNET hS = NULL, hC = NULL, hR = NULL;
+    HANDLE hFile = INVALID_HANDLE_VALUE;
+    int rc = -1;
+    BOOL secure;
+    DWORD status = 0, slen = sizeof(status);
+    BYTE buf[65536];
+
+    ZeroMemory(&uc, sizeof(uc));
+    uc.dwStructSize = sizeof(uc);
+    uc.lpszHostName = host;    uc.dwHostNameLength = ARRAYSIZE(host);
+    uc.lpszUrlPath  = upath;   uc.dwUrlPathLength  = ARRAYSIZE(upath);
+    uc.lpszExtraInfo = extra;  uc.dwExtraInfoLength = ARRAYSIZE(extra);
+    if (!WinHttpCrackUrl(url, 0, 0, &uc)) return -1;
+    secure = (uc.nScheme == INTERNET_SCHEME_HTTPS);
+    swprintf_s(fullpath, ARRAYSIZE(fullpath), L"%s%s", upath, extra);
+
+    hS = WinHttpOpen(L"AppSandbox/1.0", WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
+                     WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (!hS) goto done;
+    hC = WinHttpConnect(hS, host, uc.nPort, 0);
+    if (!hC) goto done;
+    hR = WinHttpOpenRequest(hC, L"GET", fullpath, NULL, WINHTTP_NO_REFERER,
+                            WINHTTP_DEFAULT_ACCEPT_TYPES,
+                            secure ? WINHTTP_FLAG_SECURE : 0);
+    if (!hR) goto done;
+    if (!WinHttpSendRequest(hR, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                            WINHTTP_NO_REQUEST_DATA, 0, 0, 0)) goto done;
+    if (!WinHttpReceiveResponse(hR, NULL)) goto done;
+    WinHttpQueryHeaders(hR, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                        WINHTTP_HEADER_NAME_BY_INDEX, &status, &slen, WINHTTP_NO_HEADER_INDEX);
+    if (status / 100 != 2) { ui_log(L"d3dlayers: download HTTP %lu", status); goto done; }
+
+    hFile = CreateFileW(out_path, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
+                        FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE) goto done;
+    for (;;) {
+        DWORD avail = 0, rd = 0, wr = 0;
+        if (!WinHttpQueryDataAvailable(hR, &avail)) goto done;
+        if (avail == 0) break;
+        if (avail > sizeof(buf)) avail = sizeof(buf);
+        if (!WinHttpReadData(hR, buf, avail, &rd)) goto done;
+        if (rd == 0) break;
+        if (!WriteFile(hFile, buf, rd, &wr, NULL) || wr != rd) goto done;
+    }
+    rc = 0;
+
+done:
+    if (hFile != INVALID_HANDLE_VALUE) CloseHandle(hFile);
+    if (hR) WinHttpCloseHandle(hR);
+    if (hC) WinHttpCloseHandle(hC);
+    if (hS) WinHttpCloseHandle(hS);
+    return rc;
+}
+
+/* ---- response parsing ---- */
+
+/* Find the x64 D3DMappingLayers .appx in a (decoded) SyncUpdates response and
+ * resolve its UpdateIdentity by joining the file's enclosing <Update> <ID> to
+ * the matching NewUpdates <UpdateInfo> <UpdateIdentity>. */
+static BOOL parse_x64_leaf(const char *buf, char *uid, size_t uid_cch,
+                           char *rev, size_t rev_cch, char *digest, size_t dig_cch)
+{
+    const char *p = buf;
+    while ((p = strstr(p, "<File ")) != NULL) {
+        const char *gt = strchr(p, '>');
+        char tag[1024], fn[260], isi[260];
+        const char *idp, *idend, *idtok_pos, *uip;
+        char idtok[64], idnum[32];
+        size_t taglen;
+        if (!gt) break;
+        taglen = (size_t)(gt - p);
+        if (taglen >= sizeof(tag)) { p = gt + 1; continue; }
+        memcpy(tag, p, taglen); tag[taglen] = 0;
+
+        if (!attr_in(tag, "FileName", fn, sizeof(fn)) ||
+            !attr_in(tag, "InstallerSpecificIdentifier", isi, sizeof(isi))) {
+            p = gt + 1; continue;
+        }
+        if (!strstr(isi, "D3DMappingLayers") || !strstr(isi, "_x64_") ||
+            !strstr(fn, ".appx")) {
+            p = gt + 1; continue;
+        }
+        /* matched the x64 package file */
+        attr_in(tag, "Digest", digest, dig_cch);
+
+        /* nearest <ID>N</ID> before this <File> = the ExtendedUpdateInfo id */
+        idp = rfind(buf, p, "<ID>");
+        if (!idp) return FALSE;
+        idp += 4;
+        idend = strstr(idp, "</ID>");
+        if (!idend || (size_t)(idend - idp) >= sizeof(idnum)) return FALSE;
+        memcpy(idnum, idp, (size_t)(idend - idp));
+        idnum[idend - idp] = 0;
+
+        /* first <ID>N</ID> in the buffer is the NewUpdates entry; the
+         * UpdateIdentity follows it. */
+        sprintf_s(idtok, sizeof(idtok), "<ID>%s</ID>", idnum);
+        idtok_pos = strstr(buf, idtok);
+        if (!idtok_pos) return FALSE;
+        uip = strstr(idtok_pos, "<UpdateIdentity UpdateID=\"");
+        if (!uip) return FALSE;
+        if (!between(uip, "UpdateID=\"", "\"", uid, uid_cch)) return FALSE;
+        if (!between(uip, "RevisionNumber=\"", "\"", rev, rev_cch))
+            strcpy_s(rev, rev_cch, "1");
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/* From a (decoded) GetExtendedUpdateInfo2 response, pick the CDN url for the
+ * file whose <FileDigest> matches `digest`; fall back to the first delivery
+ * CDN url. */
+static BOOL parse_file_url(const char *buf, const char *digest,
+                           wchar_t *out, size_t out_cch)
+{
+    char urla[4096];
+    const char *p;
+
+    if (digest && digest[0]) {
+        const char *d = strstr(buf, digest);
+        if (d) {
+            const char *u = strstr(d, "<Url>");
+            if (u && between(u, "<Url>", "</Url>", urla, sizeof(urla))) {
+                MultiByteToWideChar(CP_UTF8, 0, urla, -1, out, (int)out_cch);
+                return TRUE;
+            }
+        }
+    }
+    /* fallback: first delivery.mp CDN url */
+    p = buf;
+    while ((p = strstr(p, "<Url>")) != NULL) {
+        if (between(p, "<Url>", "</Url>", urla, sizeof(urla))) {
+            if (strstr(urla, "delivery.mp.microsoft.com")) {
+                MultiByteToWideChar(CP_UTF8, 0, urla, -1, out, (int)out_cch);
+                return TRUE;
+            }
+        }
+        p += 5;
+    }
+    return FALSE;
+}
+
+/* Resolve the x64 package CDN url from Microsoft. Returns 0 on success. */
+static int resolve_url(const char *wucatid, wchar_t *url_out, size_t url_cch)
+{
+    int round, rc = -1;
+    for (round = 0; round < DL_MAX_ROUNDS && rc != 0; round++) {
+        char msgid[40], created[40], expires[40];
+        char *t1, *cookie_req = NULL, *cookie_resp = NULL;
+        char cookie[8192];
+        char *sync_req = NULL, *sync_resp = NULL;
+        char uid[128] = {0}, rev[32] = {0}, digest[256] = {0};
+        char *ext_req = NULL, *ext_resp = NULL;
+
+        new_guid(msgid, sizeof(msgid));
+        iso_times(created, sizeof(created), expires, sizeof(expires));
+
+        /* GetCookie */
+        t1 = str_replace_all(FE3_TPL_GETCOOKIE, "%MSGID%", msgid);
+        if (t1) { cookie_req = str_replace_all(t1, "%CREATED%", created); free(t1); }
+        if (cookie_req) { t1 = str_replace_all(cookie_req, "%EXPIRES%", expires); free(cookie_req); cookie_req = t1; }
+        if (cookie_req) { cookie_resp = fe3_post(DL_FE3_PATH, cookie_req); free(cookie_req); }
+        if (!cookie_resp || !between(cookie_resp, "EncryptedData>", "</", cookie, sizeof(cookie))) {
+            free(cookie_resp); Sleep(1500); continue;
+        }
+        free(cookie_resp);
+
+        /* SyncUpdates */
+        new_guid(msgid, sizeof(msgid));
+        t1 = str_replace_all(FE3_TPL_SYNCUPDATES, "%MSGID%", msgid);
+        if (t1) { sync_req = str_replace_all(t1, "%CREATED%", created); free(t1); t1 = sync_req; }
+        if (t1) { sync_req = str_replace_all(t1, "%EXPIRES%", expires); free(t1); t1 = sync_req; }
+        if (t1) { sync_req = str_replace_all(t1, "%COOKIE%", cookie); free(t1); t1 = sync_req; }
+        if (t1) { sync_req = str_replace_all(t1, "%CATID%", wucatid); free(t1); }
+        if (sync_req) { sync_resp = fe3_post(DL_FE3_PATH, sync_req); free(sync_req); }
+        if (sync_resp) html_unescape(sync_resp);
+        if (!sync_resp || !parse_x64_leaf(sync_resp, uid, sizeof(uid), rev, sizeof(rev),
+                                          digest, sizeof(digest))) {
+            free(sync_resp); Sleep(1500); continue;
+        }
+        free(sync_resp);
+
+        /* GetExtendedUpdateInfo2 */
+        new_guid(msgid, sizeof(msgid));
+        t1 = str_replace_all(FE3_TPL_GETEXTENDEDINFO2, "%MSGID%", msgid);
+        if (t1) { ext_req = str_replace_all(t1, "%CREATED%", created); free(t1); t1 = ext_req; }
+        if (t1) { ext_req = str_replace_all(t1, "%EXPIRES%", expires); free(t1); t1 = ext_req; }
+        if (t1) { ext_req = str_replace_all(t1, "%UPDATEID%", uid); free(t1); t1 = ext_req; }
+        if (t1) { ext_req = str_replace_all(t1, "%REVISION%", rev); free(t1); }
+        if (ext_req) { ext_resp = fe3_post(DL_FE3_PATH_SECURED, ext_req); free(ext_req); }
+        if (ext_resp) html_unescape(ext_resp);
+        if (ext_resp && parse_file_url(ext_resp, digest, url_out, url_cch))
+            rc = 0;
+        else
+            Sleep(1500);
+        free(ext_resp);
+    }
+    return rc;
+}
+
+/* The shipped dzn_icd.x64.json gives library_path as "x64\vulkan_dzn.dll",
+ * relative to the manifest. The layers are staged into one flat directory, so
+ * point library_path at the DLL's fully-qualified location in the guest.
+ *
+ * The path must be absolute: the Vulkan loader resolves an ICD via
+ * LoadLibraryW(), falling back to LoadLibraryExW(..., LOAD_LIBRARY_SEARCH_*),
+ * and LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR requires a fully-qualified path. The
+ * path must match the GL-layers share guest_path in gpu_enum.c
+ * (gpu_append_gl_layers_share). */
+static void rewrite_dzn_json(const wchar_t *dir)
+{
+    wchar_t path[MAX_PATH];
+    FILE *f = NULL;
+    long sz;
+    char *buf, *fixed;
+    size_t rd;
+
+    swprintf_s(path, MAX_PATH, L"%s\\dzn_icd.x64.json", dir);
+    if (_wfopen_s(&f, path, L"rb") != 0 || !f) return;
+    fseek(f, 0, SEEK_END); sz = ftell(f); fseek(f, 0, SEEK_SET);
+    if (sz <= 0 || sz > 65536) { fclose(f); return; }
+    buf = (char *)malloc((size_t)sz + 1);
+    if (!buf) { fclose(f); return; }
+    rd = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    buf[rd] = 0;
+
+    /* On disk the JSON value is the 18 bytes  x64\\vulkan_dzn.dll  (two
+     * backslash characters, JSON-escaped). Match that exactly and replace it
+     * with the absolute guest path (each backslash JSON-escaped). */
+    fixed = str_replace_all(buf, "x64\\\\vulkan_dzn.dll",
+                            "C:\\\\Windows\\\\AppSandbox\\\\d3dlayers\\\\vulkan_dzn.dll");
+    free(buf);
+    if (!fixed) return;
+    if (_wfopen_s(&f, path, L"wb") == 0 && f) {
+        fwrite(fixed, 1, strlen(fixed), f);
+        fclose(f);
+    }
+    free(fixed);
+}
+
+/* ---- public API ---- */
+
+BOOL d3dlayers_ensure_cached(wchar_t *out_dir, int out_max)
+{
+    wchar_t exe_dir[MAX_PATH], cache[MAX_PATH], tmp[MAX_PATH], appx[MAX_PATH];
+    wchar_t sysdir[MAX_PATH], cmd[2048];
+    char *catalog = NULL, wucatid_a[64] = {0};
+    char wucatid[64] = {0};
+    wchar_t url[6144];
+    int i, present = 0;
+
+    get_exe_dir(exe_dir, MAX_PATH);
+    swprintf_s(cache, MAX_PATH, L"%s\\%s", exe_dir, DL_CACHE_SUBDIR);
+
+    /* Already cached? */
+    for (i = 0; i < DL_NFILES; i++) {
+        wchar_t f[MAX_PATH];
+        swprintf_s(f, MAX_PATH, L"%s\\%s", cache, DL_DST[i]);
+        if (file_exists(f)) present++;
+    }
+    if (present == DL_NFILES) {
+        wcsncpy_s(out_dir, out_max, cache, _TRUNCATE);
+        ui_log(L"d3dlayers: using cached layers at %s", cache);
+        return TRUE;
+    }
+    mkdir_p(cache);
+
+    /* 1. WuCategoryId from the Microsoft display catalog. */
+    catalog = http_body(TRUE, L"displaycatalog.mp.microsoft.com",
+                        INTERNET_DEFAULT_HTTPS_PORT, L"GET",
+                        L"/v7.0/products/" DL_PRODUCT_ID
+                        L"?languages=en-us&market=US&fieldsTemplate=Details",
+                        NULL, NULL, 0);
+    if (!catalog || !between(catalog, "\"WuCategoryId\":\"", "\"",
+                             wucatid_a, sizeof(wucatid_a))) {
+        ui_log(L"d3dlayers: could not resolve WuCategoryId from displaycatalog");
+        free(catalog);
+        return FALSE;
+    }
+    free(catalog);
+    strcpy_s(wucatid, sizeof(wucatid), wucatid_a);
+    {
+        wchar_t w[64];
+        MultiByteToWideChar(CP_UTF8, 0, wucatid, -1, w, 64);
+        ui_log(L"d3dlayers: WuCategoryId=%s", w);
+    }
+
+    /* 2. FE3 chain -> CDN url. */
+    if (resolve_url(wucatid, url, ARRAYSIZE(url)) != 0) {
+        ui_log(L"d3dlayers: FE3 did not return a download url (after %d rounds)", DL_MAX_ROUNDS);
+        return FALSE;
+    }
+
+    /* 3. Download the .appx. */
+    swprintf_s(appx, MAX_PATH, L"%s\\%s", cache, DL_APPX_NAME);
+    ui_log(L"d3dlayers: downloading D3DMappingLayers package...");
+    if (http_download(url, appx) != 0) {
+        ui_log(L"d3dlayers: package download failed");
+        return FALSE;
+    }
+
+    /* 4. Extract with in-box tar.exe (libarchive reads zip/.appx). */
+    swprintf_s(tmp, MAX_PATH, L"%s\\_extract", cache);
+    swprintf_s(cmd, ARRAYSIZE(cmd), L"cmd.exe /c rd /s /q \"%s\" 2>nul", tmp);
+    run_hidden(cmd);
+    mkdir_p(tmp);
+    GetSystemDirectoryW(sysdir, MAX_PATH);
+    swprintf_s(cmd, ARRAYSIZE(cmd), L"\"%s\\tar.exe\" -xf \"%s\" -C \"%s\"", sysdir, appx, tmp);
+    if (run_hidden(cmd) != 0) {
+        ui_log(L"d3dlayers: tar extraction failed");
+        return FALSE;
+    }
+
+    /* 5. Copy the mapping-layer files into the cache root. */
+    for (i = 0; i < DL_NFILES; i++) {
+        wchar_t src[MAX_PATH], dst[MAX_PATH];
+        swprintf_s(src, MAX_PATH, L"%s\\%s", tmp, DL_SRC[i]);
+        swprintf_s(dst, MAX_PATH, L"%s\\%s", cache, DL_DST[i]);
+        if (!CopyFileW(src, dst, FALSE))
+            ui_log(L"d3dlayers: copy %s failed: %lu", DL_DST[i], GetLastError());
+    }
+
+    /* Make the Vulkan ICD manifest point at the DLL beside it (flat layout). */
+    rewrite_dzn_json(cache);
+
+    /* Clean up the extracted tree and the .appx (keep only the DLLs). */
+    swprintf_s(cmd, ARRAYSIZE(cmd), L"cmd.exe /c rd /s /q \"%s\" 2>nul", tmp);
+    run_hidden(cmd);
+    DeleteFileW(appx);
+
+    /* Verify the files we actually need are present. */
+    present = 0;
+    for (i = 0; i < DL_NFILES; i++) {
+        wchar_t f[MAX_PATH];
+        swprintf_s(f, MAX_PATH, L"%s\\%s", cache, DL_DST[i]);
+        if (file_exists(f)) present++;
+    }
+    if (present != DL_NFILES) {
+        ui_log(L"d3dlayers: only %d/%d layer files present after extract", present, DL_NFILES);
+        return FALSE;
+    }
+
+    wcsncpy_s(out_dir, out_max, cache, _TRUNCATE);
+    ui_log(L"d3dlayers: staged %d mapping-layer files to %s", DL_NFILES, cache);
+    return TRUE;
+}

--- a/src/backend_win/d3dlayers.h
+++ b/src/backend_win/d3dlayers.h
@@ -1,0 +1,46 @@
+/*
+ * d3dlayers.h -- Host-side fetch of the Microsoft D3D mapping layers.
+ *
+ * Downloads the Microsoft.D3DMappingLayers package ("OpenCL, OpenGL, and
+ * Vulkan Compatibility Pack") directly from Microsoft's servers and extracts
+ * the redistributable mapping-layer DLLs into a host cache directory, so they
+ * can be staged into a Windows guest (see disk_util.c's manifest generation).
+ *
+ * This runs on the HOST at VM-create time; the guest never needs internet.
+ *
+ * The extracted set (in the returned directory) is:
+ *   OpenGLOn12.dll      GL  -> D3D12 ICD (the GL shim's target)
+ *   dxil.dll            shader validation, required by all layers
+ *   OpenCLOn12.dll      OpenCL -> D3D12
+ *   clon12compiler.dll  OpenCL compiler backend
+ *   vulkan_dzn.dll      Vulkan (Mesa Dozen) -> D3D12
+ *   dzn_icd.x64.json    Vulkan ICD manifest (points at vulkan_dzn.dll)
+ */
+
+#ifndef D3DLAYERS_H
+#define D3DLAYERS_H
+
+#include <windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Ensure the mapping-layer files are present in a host cache directory.
+ *
+ * On success returns TRUE and writes the absolute cache directory path
+ * (containing the files listed above) into out_dir. The result is cached
+ * across calls: if the files are already present no download occurs.
+ *
+ * Returns FALSE on any failure (no network, Microsoft service error,
+ * extraction failure). Callers treat GL/CL/Vulkan acceleration as
+ * best-effort and continue VM creation on failure.
+ */
+BOOL d3dlayers_ensure_cached(wchar_t *out_dir, int out_max);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* D3DLAYERS_H */

--- a/src/backend_win/disk_util.c
+++ b/src/backend_win/disk_util.c
@@ -1837,6 +1837,11 @@ int generate_vhdx_manifest(const wchar_t *manifest_path,
             const wchar_t *rel_guest = ds->guest_path;
             if (GetFileAttributesW(ds->host_path) == INVALID_FILE_ATTRIBUTES)
                 continue;
+            /* The GL/CL/Vulkan mapping-layer share is delivered by the guest
+               agent over Plan9 at runtime (after the GPU driver copy), not baked
+               into the image — skip it here. */
+            if (_wcsicmp(ds->share_name, L"AppSandbox.GlLayers") == 0)
+                continue;
             /* Strip "C:" or any drive prefix — keep the leading backslash */
             if (rel_guest[0] != L'\0' && rel_guest[1] == L':')
                 rel_guest += 2;

--- a/src/backend_win/fe3_templates.h
+++ b/src/backend_win/fe3_templates.h
@@ -1,0 +1,128 @@
+/* fe3_templates.h -- SOAP request envelopes for Microsoft's FE3 delivery
+ * service (the Windows Update / Microsoft Store package delivery backend).
+ *
+ * Used by d3dlayers.c to resolve, on the HOST, the download URL of the
+ * Microsoft.D3DMappingLayers package (OpenGLOn12.dll / dxil.dll / ...)
+ * straight from Microsoft's servers, then stage the DLLs into the guest.
+ *
+ * These are hand-authored minimal envelopes (Windows Update client protocol,
+ * protocolVersion 1.40). Everything volatile is substituted at runtime via
+ * tokens; nothing here is version- or host-specific:
+ *
+ *   %MSGID%    fresh WS-Addressing message UUID, generated per request
+ *   %CREATED%  WS-Security timestamp (now, UTC), generated per request
+ *   %EXPIRES%  WS-Security timestamp (now + 5 min), generated per request
+ *   %COOKIE%   GetCookie's returned EncryptedData blob (SyncUpdates only)
+ *   %CATID%    WuCategoryId, resolved at runtime from displaycatalog
+ *   %UPDATEID% / %REVISION%  the chosen package's UpdateIdentity
+ *
+ * The SyncUpdates request carries only the 56 decade-stable Windows Update
+ * "root" InstalledNonLeafUpdateIDs (the catalog tree roots). The large
+ * OtherCachedUpdateIDs list some tooling uses is a caching hint only and is
+ * intentionally omitted -- verified that the package leaf still resolves in
+ * one round-trip. d3dlayers.c locates the package by identifier in the
+ * response, so extra/changed entries do not break resolution.
+ */
+
+#ifndef FE3_TEMPLATES_H
+#define FE3_TEMPLATES_H
+
+#define FE3_WU_NS  "http://www.microsoft.com/SoftwareDistribution/Server/ClientWebService"
+
+/* Generic Windows Update client device attributes (no host-specific data). */
+#define FE3_DEVICE_ATTRS \
+    "BranchReadinessLevel=CB;CurrentBranch=rs_prerelease;OEMModel=Virtual Machine;" \
+    "FlightRing=Retail;AttrDataVer=21;SystemManufacturer=Microsoft Corporation;" \
+    "InstallLanguage=en-US;OSUILocale=en-US;InstallationType=Client;" \
+    "FlightingBranchName=external;FirmwareVersion=Hyper-V UEFI Release v2.5;" \
+    "SystemProductName=Virtual Machine;OSSkuId=48;FlightContent=Branch;App=WU;" \
+    "OEMName_Uncleaned=Microsoft Corporation;AppVer=10.0.22621.900;OSArchitecture=AMD64;" \
+    "SystemSKU=None;UpdateManagementGroup=2;IsFlightingEnabled=1;IsDeviceRetailDemo=0;" \
+    "TelemetryLevel=3;OSVersion=10.0.22621.900;DeviceFamily=Windows.Desktop;"
+
+/* The 56 stable Windows Update catalog root (non-leaf) update IDs. */
+#define FE3_NONLEAF_IDS \
+    "<int>1</int><int>2</int><int>3</int><int>11</int><int>19</int><int>544</int>" \
+    "<int>549</int><int>2359974</int><int>2359977</int><int>5169044</int><int>8788830</int>" \
+    "<int>23110993</int><int>23110994</int><int>54341900</int><int>54343656</int>" \
+    "<int>59830006</int><int>59830007</int><int>59830008</int><int>60484010</int>" \
+    "<int>62450018</int><int>62450019</int><int>62450020</int><int>66027979</int>" \
+    "<int>66053150</int><int>97657898</int><int>98822896</int><int>98959022</int>" \
+    "<int>98959023</int><int>98959024</int><int>98959025</int><int>98959026</int>" \
+    "<int>104433538</int><int>104900364</int><int>105489019</int><int>117765322</int>" \
+    "<int>129905029</int><int>130040031</int><int>132387090</int><int>132393049</int>" \
+    "<int>133399034</int><int>138537048</int><int>140377312</int><int>143747671</int>" \
+    "<int>158941041</int><int>158941042</int><int>158941043</int><int>158941044</int>" \
+    "<int>159123858</int><int>159130928</int><int>164836897</int><int>164847386</int>" \
+    "<int>164848327</int><int>164852241</int><int>164852246</int><int>164852252</int>" \
+    "<int>164852253</int>"
+
+static const char *const FE3_TPL_GETCOOKIE =
+"<Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://www.w3.org/2003/05/soap-envelope\">"
+  "<Header>"
+    "<Action d3p1:mustUnderstand=\"1\" xmlns:d3p1=\"http://www.w3.org/2003/05/soap-envelope\" xmlns=\"http://www.w3.org/2005/08/addressing\">" FE3_WU_NS "/GetCookie</Action>"
+    "<MessageID xmlns=\"http://www.w3.org/2005/08/addressing\">urn:uuid:%MSGID%</MessageID>"
+    "<To d3p1:mustUnderstand=\"1\" xmlns:d3p1=\"http://www.w3.org/2003/05/soap-envelope\" xmlns=\"http://www.w3.org/2005/08/addressing\">https://fe3.delivery.mp.microsoft.com/ClientWebService/client.asmx</To>"
+    "<Security d3p1:mustUnderstand=\"1\" xmlns:d3p1=\"http://www.w3.org/2003/05/soap-envelope\" xmlns=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">"
+      "<Timestamp xmlns=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\"><Created>%CREATED%</Created><Expires>%EXPIRES%</Expires></Timestamp>"
+      "<WindowsUpdateTicketsToken d4p1:id=\"ClientMSA\" xmlns:d4p1=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" xmlns=\"http://schemas.microsoft.com/msus/2014/10/WindowsUpdateAuthorization\"><TicketType Name=\"MSA\" Version=\"1.0\" Policy=\"MBI_SSL\"><user></user></TicketType></WindowsUpdateTicketsToken>"
+    "</Security>"
+  "</Header>"
+  "<Body>"
+    "<GetCookie xmlns=\"" FE3_WU_NS "\"><oldCookie></oldCookie><lastChange>2015-10-21T17:01:07.1472913Z</lastChange><currentTime>%CREATED%</currentTime><protocolVersion>1.40</protocolVersion></GetCookie>"
+  "</Body>"
+"</Envelope>";
+
+static const char *const FE3_TPL_SYNCUPDATES =
+"<s:Envelope xmlns:a=\"http://www.w3.org/2005/08/addressing\" xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\">"
+  "<s:Header>"
+    "<a:Action s:mustUnderstand=\"1\">" FE3_WU_NS "/SyncUpdates</a:Action>"
+    "<a:MessageID>urn:uuid:%MSGID%</a:MessageID>"
+    "<a:To s:mustUnderstand=\"1\">https://fe3.delivery.mp.microsoft.com/ClientWebService/client.asmx</a:To>"
+    "<o:Security s:mustUnderstand=\"1\" xmlns:o=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">"
+      "<Timestamp xmlns=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\"><Created>%CREATED%</Created><Expires>%EXPIRES%</Expires></Timestamp>"
+      "<wuws:WindowsUpdateTicketsToken wsu:id=\"ClientMSA\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" xmlns:wuws=\"http://schemas.microsoft.com/msus/2014/10/WindowsUpdateAuthorization\"><TicketType Name=\"MSA\" Version=\"1.0\" Policy=\"MBI_SSL\"><user></user></TicketType></wuws:WindowsUpdateTicketsToken>"
+    "</o:Security>"
+  "</s:Header>"
+  "<s:Body>"
+    "<SyncUpdates xmlns=\"" FE3_WU_NS "\">"
+      "<cookie><Expiration>2050-01-01T00:00:00Z</Expiration><EncryptedData>%COOKIE%</EncryptedData></cookie>"
+      "<parameters>"
+        "<ExpressQuery>false</ExpressQuery>"
+        "<InstalledNonLeafUpdateIDs>" FE3_NONLEAF_IDS "</InstalledNonLeafUpdateIDs>"
+        "<OtherCachedUpdateIDs></OtherCachedUpdateIDs>"
+        "<SkipSoftwareSync>false</SkipSoftwareSync>"
+        "<NeedTwoGroupOutOfScopeUpdates>true</NeedTwoGroupOutOfScopeUpdates>"
+        "<FilterAppCategoryIds><CategoryIdentifier><Id>%CATID%</Id></CategoryIdentifier></FilterAppCategoryIds>"
+        "<TreatAppCategoryIdsAsInstalled>true</TreatAppCategoryIdsAsInstalled>"
+        "<AlsoPerformRegularSync>false</AlsoPerformRegularSync>"
+        "<ComputerSpec/>"
+        "<ExtendedUpdateInfoParameters><XmlUpdateFragmentTypes><XmlUpdateFragmentType>Extended</XmlUpdateFragmentType></XmlUpdateFragmentTypes><Locales><string>en-US</string><string>en</string></Locales></ExtendedUpdateInfoParameters>"
+        "<ClientPreferredLanguages><string>en-US</string></ClientPreferredLanguages>"
+        "<ProductsParameters><SyncCurrentVersionOnly>false</SyncCurrentVersionOnly><DeviceAttributes>" FE3_DEVICE_ATTRS "</DeviceAttributes><CallerAttributes>Interactive=1;IsSeeker=0;</CallerAttributes><Products/></ProductsParameters>"
+      "</parameters>"
+    "</SyncUpdates>"
+  "</s:Body>"
+"</s:Envelope>";
+
+static const char *const FE3_TPL_GETEXTENDEDINFO2 =
+"<s:Envelope xmlns:a=\"http://www.w3.org/2005/08/addressing\" xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\">"
+  "<s:Header>"
+    "<a:Action s:mustUnderstand=\"1\">" FE3_WU_NS "/GetExtendedUpdateInfo2</a:Action>"
+    "<a:MessageID>urn:uuid:%MSGID%</a:MessageID>"
+    "<a:To s:mustUnderstand=\"1\">https://fe3.delivery.mp.microsoft.com/ClientWebService/client.asmx/secured</a:To>"
+    "<o:Security s:mustUnderstand=\"1\" xmlns:o=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">"
+      "<Timestamp xmlns=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\"><Created>%CREATED%</Created><Expires>%EXPIRES%</Expires></Timestamp>"
+      "<wuws:WindowsUpdateTicketsToken wsu:id=\"ClientMSA\" xmlns:wsu=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" xmlns:wuws=\"http://schemas.microsoft.com/msus/2014/10/WindowsUpdateAuthorization\"><TicketType Name=\"MSA\" Version=\"1.0\" Policy=\"MBI_SSL\"><user></user></TicketType></wuws:WindowsUpdateTicketsToken>"
+    "</o:Security>"
+  "</s:Header>"
+  "<s:Body>"
+    "<GetExtendedUpdateInfo2 xmlns=\"" FE3_WU_NS "\">"
+      "<updateIDs><UpdateIdentity><UpdateID>%UPDATEID%</UpdateID><RevisionNumber>%REVISION%</RevisionNumber></UpdateIdentity></updateIDs>"
+      "<infoTypes><XmlUpdateFragmentType>FileUrl</XmlUpdateFragmentType><XmlUpdateFragmentType>FileDecryption</XmlUpdateFragmentType></infoTypes>"
+      "<deviceAttributes>" FE3_DEVICE_ATTRS "</deviceAttributes>"
+    "</GetExtendedUpdateInfo2>"
+  "</s:Body>"
+"</s:Envelope>";
+
+#endif /* FE3_TEMPLATES_H */

--- a/src/backend_win/gpu_enum.c
+++ b/src/backend_win/gpu_enum.c
@@ -500,6 +500,25 @@ BOOL gpu_append_lxsslib_share(GpuDriverShareList *list)
     return TRUE;
 }
 
+BOOL gpu_append_gl_layers_share(GpuDriverShareList *list, const wchar_t *host_dir)
+{
+    GpuDriverShare *s;
+
+    if (!list || !host_dir || !host_dir[0]) return FALSE;
+    if (list->count >= MAX_GPU_SHARES) return FALSE;
+    if (GetFileAttributesW(host_dir) == INVALID_FILE_ATTRIBUTES) return FALSE;
+
+    s = &list->shares[list->count];
+    /* Recognised by name on both sides: disk_util skips it for build-time
+     * staging; the guest agent copies it last and then provisions it. */
+    wcscpy_s(s->share_name, 128, L"AppSandbox.GlLayers");
+    wcscpy_s(s->host_path, MAX_PATH, host_dir);
+    wcscpy_s(s->guest_path, MAX_PATH, L"C:\\Windows\\AppSandbox\\d3dlayers");
+    s->file_filter[0] = L'\0';
+    list->count++;
+    return TRUE;
+}
+
 BOOL gpu_get_default_driver_path(GpuList *list,
     wchar_t *out_path, int path_max,
     wchar_t *out_folder, int folder_max)

--- a/src/backend_win/gpu_enum.h
+++ b/src/backend_win/gpu_enum.h
@@ -59,4 +59,13 @@ BOOL gpu_get_driver_shares(GpuList *gpu_list, GpuDriverShareList *out);
    list is full. */
 BOOL gpu_append_lxsslib_share(GpuDriverShareList *list);
 
+/* Append a synthetic Plan9 share (name "AppSandbox.GlLayers") exposing the
+   host directory that holds the D3D mapping layers (OpenGLOn12/dxil/OpenCLOn12/
+   clon12compiler/vulkan_dzn + dzn_icd.x64.json) and the OpenGL ICD shim. The
+   Windows guest agent copies this share AFTER the GPU driver shares and then
+   provisions it (stages dxil to System32, sets AppInit_DLLs + the Khronos
+   OpenCL/Vulkan ICD registry keys). guest_path is C:\Windows\AppSandbox\d3dlayers.
+   Windows guests only. Returns TRUE if added. */
+BOOL gpu_append_gl_layers_share(GpuDriverShareList *list, const wchar_t *host_dir);
+
 #endif /* GPU_ENUM_H */

--- a/tools/agent/agent.c
+++ b/tools/agent/agent.c
@@ -392,6 +392,81 @@ static BOOL logoff_session(DWORD session_id)
     return result;
 }
 
+/* Provision the D3D mapping layers after the agent has copied them into `dir`
+   (C:\Windows\AppSandbox\d3dlayers) over Plan9. Runs as SYSTEM from the GPU
+   copy thread, AFTER the GPU driver copy. Stages dxil.dll into System32 (the
+   layers load it by leaf name) and registers the ICDs: OpenGL via AppInit_DLLs
+   (full path to the shim), OpenCL + Vulkan via their Khronos registry keys.
+   Each step is gated on the file being present; idempotent across boots. */
+static void gl_provision(const wchar_t *dir)
+{
+    wchar_t path[MAX_PATH], sys[MAX_PATH], dst[MAX_PATH];
+    HKEY key;
+    DWORD one = 1, zero = 0;
+
+    agent_log("GL: provisioning mapping layers from %ls", dir);
+
+    /* dxil.dll -> System32 (OpenGLOn12 / vulkan_dzn load it by leaf name). */
+    if (GetSystemDirectoryW(sys, MAX_PATH)) {
+        swprintf_s(path, MAX_PATH, L"%s\\dxil.dll", dir);
+        swprintf_s(dst, MAX_PATH, L"%s\\dxil.dll", sys);
+        if (GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES) {
+            if (CopyFileW(path, dst, FALSE))
+                agent_log("GL: staged dxil.dll to System32.");
+            else
+                agent_log("GL: dxil.dll -> System32 failed (%lu).", GetLastError());
+        }
+    }
+
+    /* OpenGL: AppInit_DLLs = full path to the shim; enable; allow unsigned. */
+    swprintf_s(path, MAX_PATH, L"%s\\appsandbox_gl_shim.dll", dir);
+    if (GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES) {
+        if (RegCreateKeyExW(HKEY_LOCAL_MACHINE,
+                L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows",
+                0, NULL, 0, KEY_SET_VALUE, NULL, &key, NULL) == ERROR_SUCCESS) {
+            RegSetValueExW(key, L"AppInit_DLLs", 0, REG_SZ,
+                           (const BYTE *)path, (DWORD)((wcslen(path) + 1) * sizeof(wchar_t)));
+            RegSetValueExW(key, L"LoadAppInit_DLLs", 0, REG_DWORD,
+                           (const BYTE *)&one, sizeof(one));
+            RegSetValueExW(key, L"RequireSignedAppInit_DLLs", 0, REG_DWORD,
+                           (const BYTE *)&zero, sizeof(zero));
+            RegCloseKey(key);
+            agent_log("GL: AppInit_DLLs set to %ls", path);
+        } else {
+            agent_log("GL: failed to open AppInit_DLLs key.");
+        }
+    } else {
+        agent_log("GL: shim not present in share; OpenGL not enabled.");
+    }
+
+    /* OpenCL: Khronos vendor key — value name = ICD path, data 0 (= load it). */
+    swprintf_s(path, MAX_PATH, L"%s\\OpenCLOn12.dll", dir);
+    if (GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES) {
+        if (RegCreateKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Khronos\\OpenCL\\Vendors",
+                0, NULL, 0, KEY_SET_VALUE, NULL, &key, NULL) == ERROR_SUCCESS) {
+            RegSetValueExW(key, path, 0, REG_DWORD, (const BYTE *)&zero, sizeof(zero));
+            RegCloseKey(key);
+            agent_log("GL: registered OpenCL ICD %ls", path);
+        }
+    }
+
+    /* Vulkan: Khronos driver key — value name = ICD manifest path, data 0.
+       The manifest's library_path is the absolute guest DLL path (set host-side
+       in d3dlayers.c) so the loader can LoadLibraryEx it under
+       LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR, which requires a fully-qualified path. */
+    swprintf_s(path, MAX_PATH, L"%s\\dzn_icd.x64.json", dir);
+    if (GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES) {
+        if (RegCreateKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Khronos\\Vulkan\\Drivers",
+                0, NULL, 0, KEY_SET_VALUE, NULL, &key, NULL) == ERROR_SUCCESS) {
+            RegSetValueExW(key, path, 0, REG_DWORD, (const BYTE *)&zero, sizeof(zero));
+            RegCloseKey(key);
+            agent_log("GL: registered Vulkan (Dozen) ICD %ls", path);
+        }
+    }
+
+    agent_log("GL: provisioning complete.");
+}
+
 static DWORD WINAPI gpu_copy_thread(LPVOID param)
 {
     GpuCopyState *state = (GpuCopyState *)param;
@@ -399,7 +474,9 @@ static DWORD WINAPI gpu_copy_thread(LPVOID param)
     int total_files = 0;
     int failed_shares = 0;
     char msg[256];
+    wchar_t gl_dir[MAX_PATH];
 
+    gl_dir[0] = 0;
     agent_log("GPU copy starting (%d shares)...", state->count);
 
     for (i = 0; i < state->count; i++) {
@@ -409,6 +486,10 @@ static DWORD WINAPI gpu_copy_thread(LPVOID param)
         int rc;
 
         MultiByteToWideChar(CP_UTF8, 0, si->dest_path, -1, dest_wide, MAX_PATH);
+
+        /* The GL mapping-layer share is provisioned after the copy loop. */
+        if (strcmp(si->share_name, "AppSandbox.GlLayers") == 0)
+            wcscpy_s(gl_dir, MAX_PATH, dest_wide);
 
         agent_log("GPU copy share %d/%d: %s -> %s%s%s",
                   i + 1, state->count, si->share_name, si->dest_path,
@@ -431,6 +512,13 @@ static DWORD WINAPI gpu_copy_thread(LPVOID param)
         if (state->notify_sock != INVALID_SOCKET)
             send_line(state->notify_sock, msg);
     }
+
+    /* Provision the GL/CL/Vulkan mapping layers now — AFTER the GPU driver copy
+       but BEFORE the device disable/enable cycle, so the ICD configuration
+       (AppInit_DLLs + Khronos OpenCL/Vulkan keys + dxil.dll in System32) is in
+       place when the GPU device is restarted below. */
+    if (gl_dir[0])
+        gl_provision(gl_dir);
 
     /* If files were copied and vrd.inf has error 43, restart GPU + IDD devices
        and re-disable Hyper-V Video adapter. */

--- a/tools/gl-shim/appsandbox_gl_shim.c
+++ b/tools/gl-shim/appsandbox_gl_shim.c
@@ -1,0 +1,243 @@
+/*
+ * appsandbox_gl_shim.dll
+ *
+ * Loaded into every user32-linking process via AppInit_DLLs. IAT-hooks
+ * opengl32.dll's import of gdi32!D3DKMTQueryAdapterInfo. When opengl32
+ * queries KMTQAITYPE_UMOPENGLINFO to learn which ICD to load, the hook
+ * rewrites the returned UmdOpenGlIcdFileName to point at OpenGLOn12.dll
+ * (the Mesa GL-on-D3D12 ICD that AppSandbox stages into the guest).
+ *
+ * Inside a GPU-PV guest the kernel advertises the host's native OpenGL ICD
+ * (e.g. nvoglv64.dll, projected via HostDriverStore) which cannot initialise
+ * because the guest has no matching kernel driver, so opengl32 falls back to
+ * GDI Generic 1.1 software. Redirecting the ICD to OpenGLOn12.dll routes GL
+ * through D3D12 -> GPU-PV -> host GPU instead.
+ *
+ * Defensive throughout -- this loads into *every* user32-using process
+ * (including system services) and must never throw or crash any process.
+ *
+ * Build: MSVC, x64, /MT (static CRT so there is no runtime-DLL dependency in
+ * arbitrary guest processes). Exposes no exports; all work happens in DllMain.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <wchar.h>
+
+/* ---- D3DKMT ABI ---- */
+typedef LONG  NTSTATUS;
+typedef ULONG D3DKMT_HANDLE;
+#define KMTQAITYPE_UMOPENGLINFO 2
+
+typedef struct {
+    D3DKMT_HANDLE hAdapter;
+    INT           Type;
+    PVOID         pPrivateDriverData;
+    UINT          PrivateDriverDataSize;
+} D3DKMT_QUERYADAPTERINFO_T;
+
+typedef struct {
+    WCHAR UmdOpenGlIcdFileName[260];
+    ULONG Version;
+    ULONG Flags;
+} D3DKMT_OPENGLINFO_T;
+
+typedef NTSTATUS (APIENTRY *PFN_D3DKMTQueryAdapterInfo)(D3DKMT_QUERYADAPTERINFO_T*);
+
+/* ---- ntdll LdrRegisterDllNotification ABI ---- */
+typedef struct _UNICODE_STRING_T {
+    USHORT Length;
+    USHORT MaximumLength;
+    PWSTR  Buffer;
+} UNICODE_STRING_T, *PUNICODE_STRING_T;
+typedef const UNICODE_STRING_T* PCUNICODE_STRING_T;
+
+typedef struct {
+    ULONG               Flags;
+    PCUNICODE_STRING_T  FullDllName;
+    PCUNICODE_STRING_T  BaseDllName;
+    PVOID               DllBase;
+    ULONG               SizeOfImage;
+} LDR_DLL_NOTIFICATION_DATA_T;
+
+#define LDR_DLL_NOTIFICATION_REASON_LOADED 1
+
+typedef VOID (NTAPI *PLDR_DLL_NOTIFICATION_FUNCTION)(
+    ULONG, LDR_DLL_NOTIFICATION_DATA_T*, PVOID);
+typedef NTSTATUS (NTAPI *PFN_LdrRegisterDllNotification)(
+    ULONG, PLDR_DLL_NOTIFICATION_FUNCTION, PVOID, PVOID*);
+
+/* ---- Globals ---- */
+static PFN_D3DKMTQueryAdapterInfo g_real_query = NULL;
+/* TARGET PATH: the OpenGLOn12.dll copy AppSandbox stages into the guest
+ * (see disk_util.c manifest: \Windows\AppSandbox\d3dlayers\OpenGLOn12.dll). */
+static const WCHAR* g_target_icd =
+    L"C:\\Windows\\AppSandbox\\d3dlayers\\OpenGLOn12.dll";
+
+static CRITICAL_SECTION g_log_cs;
+static volatile LONG    g_log_init = 0;
+static FILE*            g_log_fp   = NULL;
+static volatile LONG    g_hook_installed = 0;
+static PVOID            g_ldr_cookie = NULL;
+
+/* ---- Logging (one log file per PID under C:\ProgramData\appsandbox_shim) ---- */
+static void ensure_log(void) {
+    char dir[MAX_PATH] = "C:\\ProgramData\\appsandbox_shim";
+    char exepath[MAX_PATH] = {0};
+    const char* leaf;
+    char path[MAX_PATH];
+
+    if (InterlockedCompareExchange(&g_log_init, 1, 0) != 0) return;
+    InitializeCriticalSection(&g_log_cs);
+
+    CreateDirectoryA(dir, NULL);
+
+    GetModuleFileNameA(NULL, exepath, sizeof(exepath));
+    leaf = strrchr(exepath, '\\');
+    leaf = leaf ? leaf + 1 : exepath;
+    snprintf(path, sizeof(path), "%s\\%lu_%s.log", dir,
+             (unsigned long)GetCurrentProcessId(), leaf);
+    g_log_fp = fopen(path, "a");
+}
+
+static void shimlog(const char* fmt, ...) {
+    va_list ap;
+    char ts[64];
+    SYSTEMTIME t;
+
+    ensure_log();
+    if (!g_log_fp) return;
+    EnterCriticalSection(&g_log_cs);
+    GetLocalTime(&t);
+    snprintf(ts, sizeof(ts), "%02u:%02u:%02u.%03u",
+             t.wHour, t.wMinute, t.wSecond, t.wMilliseconds);
+    fprintf(g_log_fp, "[%s] ", ts);
+    va_start(ap, fmt);
+    vfprintf(g_log_fp, fmt, ap);
+    va_end(ap);
+    fputc('\n', g_log_fp);
+    fflush(g_log_fp);
+    LeaveCriticalSection(&g_log_cs);
+}
+
+/* ---- The hook ---- */
+static NTSTATUS APIENTRY HookedQueryAdapterInfo(D3DKMT_QUERYADAPTERINFO_T* q) {
+    NTSTATUS r;
+    if (!g_real_query) return (NTSTATUS)0xC0000001L;
+    r = g_real_query(q);
+    if (r == 0 && q && q->Type == KMTQAITYPE_UMOPENGLINFO &&
+        q->pPrivateDriverData &&
+        q->PrivateDriverDataSize >= sizeof(D3DKMT_OPENGLINFO_T))
+    {
+        D3DKMT_OPENGLINFO_T* gl = (D3DKMT_OPENGLINFO_T*)q->pPrivateDriverData;
+        WCHAR before[260];
+        wcsncpy(before, gl->UmdOpenGlIcdFileName, 260); before[259] = 0;
+        wcsncpy(gl->UmdOpenGlIcdFileName, g_target_icd, 260);
+        gl->UmdOpenGlIcdFileName[259] = 0;
+        shimlog("UMOPENGLINFO rewrite: \"%ls\" -> \"%ls\" (hAdapter=0x%lx)",
+                before, g_target_icd, (unsigned long)q->hAdapter);
+    }
+    return r;
+}
+
+/* ---- IAT patch on opengl32's import of gdi32!D3DKMTQueryAdapterInfo ---- */
+static int patch_iat(HMODULE target) {
+    BYTE* base = (BYTE*)target;
+    IMAGE_DOS_HEADER* dos = (IMAGE_DOS_HEADER*)base;
+    IMAGE_NT_HEADERS* nt;
+    IMAGE_DATA_DIRECTORY* d;
+    IMAGE_IMPORT_DESCRIPTOR* imp;
+    int patched = 0;
+
+    if (dos->e_magic != IMAGE_DOS_SIGNATURE) return 0;
+    nt = (IMAGE_NT_HEADERS*)(base + dos->e_lfanew);
+    if (nt->Signature != IMAGE_NT_SIGNATURE) return 0;
+    d = &nt->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
+    if (!d->VirtualAddress || !d->Size) return 0;
+    imp = (IMAGE_IMPORT_DESCRIPTOR*)(base + d->VirtualAddress);
+    for (; imp->Name; imp++) {
+        const char* dll = (const char*)(base + imp->Name);
+        IMAGE_THUNK_DATA* origT;
+        IMAGE_THUNK_DATA* iatT;
+        if (_stricmp(dll, "gdi32.dll") != 0) continue;
+
+        origT = imp->OriginalFirstThunk
+            ? (IMAGE_THUNK_DATA*)(base + imp->OriginalFirstThunk)
+            : (IMAGE_THUNK_DATA*)(base + imp->FirstThunk);
+        iatT  = (IMAGE_THUNK_DATA*)(base + imp->FirstThunk);
+
+        for (; origT->u1.AddressOfData; origT++, iatT++) {
+            IMAGE_IMPORT_BY_NAME* by;
+            DWORD oldProt;
+            void* prev;
+            if (IMAGE_SNAP_BY_ORDINAL(origT->u1.Ordinal)) continue;
+            by = (IMAGE_IMPORT_BY_NAME*)(base + origT->u1.AddressOfData);
+            if (strcmp((const char*)by->Name, "D3DKMTQueryAdapterInfo") != 0) continue;
+
+            if (!VirtualProtect(&iatT->u1.Function, sizeof(uintptr_t),
+                                PAGE_READWRITE, &oldProt)) return 0;
+            prev = (void*)(uintptr_t)iatT->u1.Function;
+            if (!g_real_query) g_real_query = (PFN_D3DKMTQueryAdapterInfo)prev;
+            iatT->u1.Function = (uintptr_t)HookedQueryAdapterInfo;
+            VirtualProtect(&iatT->u1.Function, sizeof(uintptr_t),
+                           oldProt, &oldProt);
+            patched = 1;
+            shimlog("IAT patched: opengl32!gdi32.D3DKMTQueryAdapterInfo prev=%p new=%p",
+                    prev, (void*)HookedQueryAdapterInfo);
+        }
+    }
+    return patched;
+}
+
+static void try_hook_opengl32(void) {
+    HMODULE m = GetModuleHandleW(L"opengl32.dll");
+    if (!m) return;
+    if (InterlockedExchange(&g_hook_installed, 1) != 0) return;
+    if (!patch_iat(m)) {
+        InterlockedExchange(&g_hook_installed, 0);
+        shimlog("opengl32 IAT patch FAILED");
+    }
+}
+
+/* ---- LdrRegisterDllNotification: catch later opengl32 loads ---- */
+static VOID NTAPI dll_notification(ULONG reason,
+                                   LDR_DLL_NOTIFICATION_DATA_T* data,
+                                   PVOID ctx)
+{
+    PCUNICODE_STRING_T n;
+    (void)ctx;
+    if (reason != LDR_DLL_NOTIFICATION_REASON_LOADED) return;
+    if (!data || !data->BaseDllName || !data->BaseDllName->Buffer) return;
+    n = data->BaseDllName;
+    if (n->Length / sizeof(WCHAR) >= 8 &&
+        _wcsnicmp(n->Buffer, L"opengl32", 8) == 0)
+    {
+        shimlog("ldr notify: opengl32.dll loaded at %p", data->DllBase);
+        try_hook_opengl32();
+    }
+}
+
+BOOL APIENTRY DllMain(HMODULE hMod, DWORD reason, LPVOID resvd) {
+    (void)resvd;
+    if (reason == DLL_PROCESS_ATTACH) {
+        HMODULE ntdll;
+        DisableThreadLibraryCalls(hMod);
+        shimlog("PROCESS_ATTACH");
+        try_hook_opengl32();
+        ntdll = GetModuleHandleW(L"ntdll.dll");
+        if (ntdll) {
+            PFN_LdrRegisterDllNotification reg =
+                (PFN_LdrRegisterDllNotification)(uintptr_t)
+                GetProcAddress(ntdll, "LdrRegisterDllNotification");
+            if (reg) {
+                NTSTATUS s = reg(0, dll_notification, NULL, &g_ldr_cookie);
+                shimlog("LdrRegisterDllNotification status=0x%08lx cookie=%p",
+                        (unsigned long)s, g_ldr_cookie);
+            }
+        }
+    }
+    return TRUE;
+}

--- a/tools/gl-shim/appsandbox_gl_shim.vcxproj
+++ b/tools/gl-shim/appsandbox_gl_shim.vcxproj
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{C7D8E9FA-1B2C-3D4E-5F60-7A8B9C0D1E2F}</ProjectGuid>
+    <RootNamespace>appsandboxglshim</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(SolutionDir)bin\$(Configuration)-ARM64\</OutDir>
+    <IntDir>$(SolutionDir)obj\appsandbox_gl_shim\$(Configuration)-ARM64\</IntDir>
+    <TargetName>appsandbox_gl_shim</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)obj\appsandbox_gl_shim\$(Configuration)\</IntDir>
+    <TargetName>appsandbox_gl_shim</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <OutDir>$(SolutionDir)bin\$(Configuration)-ARM64\</OutDir>
+    <IntDir>$(SolutionDir)obj\appsandbox_gl_shim\$(Configuration)-ARM64\</IntDir>
+    <TargetName>appsandbox_gl_shim</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)obj\appsandbox_gl_shim\$(Configuration)\</IntDir>
+    <TargetName>appsandbox_gl_shim</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;UNICODE;_UNICODE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;UNICODE;_UNICODE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;UNICODE;_UNICODE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>if not exist "$(SolutionDir)release\resources\" mkdir "$(SolutionDir)release\resources\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)release\resources\"</Command>
+      <Message>Copying appsandbox_gl_shim.dll to release\resources\</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;UNICODE;_UNICODE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>false</SDLCheck>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>if not exist "$(SolutionDir)release\resources\" mkdir "$(SolutionDir)release\resources\"
+xcopy /Y "$(TargetPath)" "$(SolutionDir)release\resources\"</Command>
+      <Message>Copying appsandbox_gl_shim.dll to release\resources\</Message>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="appsandbox_gl_shim.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>


### PR DESCRIPTION
Provision the Microsoft D3D mapping layers (OpenGLOn12, OpenCLOn12, Dozen) into Windows GPU-PV guests so apps get hardware-accelerated GL/CL/Vulkan on top of the projected host D3D12 driver.

- d3dlayers.c/.h: fetch the D3DMappingLayers package from Microsoft on demand over WinHTTP (displaycatalog -> FE3 -> CDN), extract with in-box tar, cache beside the exe. Sets the Dozen ICD manifest library_path to the absolute guest path (the Vulkan loader's LoadLibraryEx fallback uses LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR, which requires a fully-qualified path).
- fe3_templates.h: SOAP envelopes for the FE3 client.
- gpu_enum.c/.h: add the AppSandbox.GlLayers Plan 9 share (guest path C:\Windows\AppSandbox\d3dlayers).
- asb_core.c: stage the layers + OpenGL shim and append the share before VM start.
- disk_util.c: skip the GlLayers share during build-time image staging.
- agent.c: gl_provision() copies dxil.dll to System32 and registers the ICDs (OpenGL via AppInit_DLLs shim, OpenCL + Vulkan via Khronos registry keys) after the GPU driver copy, before the device disable/enable cycle.
- tools/gl-shim: appsandbox_gl_shim.dll, an AppInit_DLLs shim that IAT-hooks gdi32!D3DKMTQueryAdapterInfo to route opengl32 to OpenGLOn12.dll.
- AppSandbox.sln / AppSandboxCore.vcxproj: build wiring.