### PR TITLE
Include OS in release zip names

### DIFF
--- a/tools/sign/SIGNING.md
+++ b/tools/sign/SIGNING.md
@@ -112,7 +112,7 @@ tools\sign\make-release.ps1
 - **If the EV YubiKey is in:** EV-signs all binaries — app `.exe`/`.dll` **and** driver
   `.sys`/`.dll` — in one call (**PIN 1**); then `sign-drivers.ps1` regenerates + EV-signs the
   catalogs (**PIN 2**) and EV-signs the cabs (**PIN 3**), submits both drivers to Microsoft,
-  waits, and downloads the MS-signed drivers; then writes `bin\Release\AppSandbox-<ver>-x64.zip`
+  waits, and downloads the MS-signed drivers; then writes `bin\Release\AppSandbox-<ver>-win-x64.zip`
   (no `.pdb`/intermediates, MS-signed drivers swapped in, test `.cer` dropped). **Three PINs
   total.** (If `bin\Release\drivers-signed\` already exists it's reused — no resubmit.)
 - **If the YubiKey is out:** stops after the build — no signing, no ZIP.

--- a/tools/sign/SIGNING_MAC.md
+++ b/tools/sign/SIGNING_MAC.md
@@ -236,10 +236,13 @@ This script runs the full pipeline:
 6. **Staple** the ticket to the `.app` (`stapler staple`) so it verifies offline.
 7. **Gatekeeper check** (`spctl`) — expects `accepted / Notarized Developer ID`.
 8. **Package** — wipe and recreate `packageDir` (default
-   `bin/Release/release_package/`) and write only the stapled
-   `AppSandbox.zip` into it. That folder is the public deliverable and contains
-   **nothing else** — no dSYMs, no loose binaries, no build scratch. The working
-   submission zip is deleted.
+   `bin/Release/release_package/`) and write only the stapled zip into it, named
+   `<productName>-<version>-<os>-<platform>.zip` (e.g.
+   `AppSandbox-0.1.0-mac-arm64.zip`), matching the Windows
+   `make-release.ps1` convention (`AppSandbox-0.1.0-win-x64.zip`). The version
+   comes from `Directory.Build.props`. That folder is the public deliverable and
+   contains **nothing else** — no dSYMs, no loose binaries, no build scratch. The
+   working submission zip is deleted.
 
 For a quick local Developer ID build without contacting Apple:
 

--- a/tools/sign/mac-release-config.json
+++ b/tools/sign/mac-release-config.json
@@ -7,9 +7,11 @@
 
   "appPath": "bin/Release/AppSandbox.app",
 
-  "_packaging": "The final public deliverable is written to packageDir/zipName and nothing else goes in that folder. packageDir is wiped and recreated each run so it only ever contains files we intend to ship.",
+  "_packaging": "The final public deliverable is written to packageDir as <productName>-<version>-<os>-<platform>.zip (e.g. AppSandbox-0.1.0-mac-arm64.zip), matching the Windows make-release.ps1 naming. version is derived from Directory.Build.props (via version.xcconfig); nothing else goes in packageDir, which is wiped and recreated each run.",
   "packageDir": "bin/Release/release_package",
-  "zipName": "AppSandbox.zip",
+  "productName": "AppSandbox",
+  "os": "mac",
+  "platform": "arm64",
 
   "expectedIdentity": "Developer ID Application"
 }

--- a/tools/sign/make-release-mac.sh
+++ b/tools/sign/make-release-mac.sh
@@ -63,7 +63,9 @@ SCHEME="$(jget "$CONFIG" scheme)"
 CONFIGURATION="$(jget "$CONFIG" configuration)"
 APP_PATH="$(jget "$CONFIG" appPath)"
 PACKAGE_DIR="$(jget "$CONFIG" packageDir)"
-ZIP_NAME="$(jget "$CONFIG" zipName)"
+PRODUCT_NAME="$(jget "$CONFIG" productName)"
+OS_TAG="$(jget "$CONFIG" os)"
+PLATFORM="$(jget "$CONFIG" platform)"
 EXPECTED_IDENTITY="$(jget "$CONFIG" expectedIdentity)"
 
 PROFILE="$(jget "$LOCAL" notaryKeychainProfile)"
@@ -71,12 +73,14 @@ APPLE_ID="$(jget "$LOCAL" appleId)"
 TEAM_ID="$(jget "$LOCAL" teamId)"
 APP_PW="$(jget "$LOCAL" appSpecificPassword)"
 
-[[ -n "$PROJECT" && -n "$SCHEME" && -n "$CONFIGURATION" && -n "$APP_PATH" && -n "$PACKAGE_DIR" && -n "$ZIP_NAME" ]] \
+[[ -n "$PROJECT" && -n "$SCHEME" && -n "$CONFIGURATION" && -n "$APP_PATH" \
+   && -n "$PACKAGE_DIR" && -n "$PRODUCT_NAME" && -n "$OS_TAG" && -n "$PLATFORM" ]] \
     || die "mac-release-config.json missing required keys"
 
-PKG_ZIP="$PACKAGE_DIR/$ZIP_NAME"
 # Working zip used only for notarization submission; never shipped.
 SUBMIT_ZIP="$(dirname "$APP_PATH")/.notarize-submit.zip"
+# PKG_ZIP is set after the version sync (it embeds the version in the name).
+PKG_ZIP=""
 
 # Publish ONLY the final zip into a clean package dir — nothing else (no dSYMs,
 # no loose products, no build scratch) ever lands there. This is a production
@@ -91,6 +95,13 @@ publish_package() {
 # --- 1. build ---
 step "Syncing version from Directory.Build.props"
 "$SCRIPT_DIR/sync-mac-version.sh"
+
+# Compose the public zip name to match the Windows convention:
+#   <productName>-<version>-<os>-<platform>.zip   e.g. AppSandbox-0.1.0-mac-arm64.zip
+# Version is MARKETING_VERSION from the just-generated version.xcconfig.
+VERSION="$(grep -E '^MARKETING_VERSION' "$ROOT/src/app_mac/xcconfig/version.xcconfig" | sed 's/.*=[[:space:]]*//' | tr -d '[:space:]')"
+[[ -n "$VERSION" ]] || die "could not read MARKETING_VERSION from version.xcconfig"
+PKG_ZIP="$PACKAGE_DIR/${PRODUCT_NAME}-${VERSION}-${OS_TAG}-${PLATFORM}.zip"
 
 step "Building $SCHEME ($CONFIGURATION)"
 xcodebuild -project "$PROJECT" -scheme "$SCHEME" -configuration "$CONFIGURATION" clean >/dev/null

--- a/tools/sign/make-release.ps1
+++ b/tools/sign/make-release.ps1
@@ -23,6 +23,7 @@
 param(
   [string]$Configuration = 'Release',
   [string]$Platform      = 'x64',
+  [string]$OS            = 'win',   # OS token in the zip name; not passed to MSBuild
   [string]$Version       = '',     # empty => read from Directory.Build.props (single source)
   [switch]$NoBuild,
   [switch]$BuildOnly,
@@ -359,7 +360,7 @@ $files | ForEach-Object { Write-Host ("  " + $_.FullName.Substring($stage.Length
 $mb = [math]::Round((($files | Measure-Object Length -Sum).Sum) / 1MB, 1)
 Write-Host ("--- {0} files, {1} MB ---`n" -f $files.Count, $mb)
 
-$zip = Join-Path $bin ("AppSandbox-{0}-{1}.zip" -f $Version, $Platform)
+$zip = Join-Path $bin ("AppSandbox-{0}-{1}-{2}.zip" -f $Version, $OS, $Platform)
 if (Test-Path $zip) { Remove-Item $zip -Force }
 # Flat layout: the items sit at the zip root (file.zip\AppSandbox.exe, file.zip\drivers\...),
 # with the drivers\ / resources\ / web\ subfolders preserved - no extra parent folder.


### PR DESCRIPTION
- Windows (make-release.ps1): add an $OS param (default 'win') used only in the zip filename; $Platform is untouched so MSBuild is unaffected. Produces AppSandbox-<ver>-win-x64.zip. SIGNING.md updated to match.
- macOS (make-release-mac.sh + mac-release-config.json): name the package <productName>-<version>-<os>-<platform>.zip from productName/os/platform plus the version derived from Directory.Build.props. Produces AppSandbox-<ver>-mac-arm64.zip. SIGNING_MAC.md updated.