### PR TITLE
Fix create-modal RAM 2 MB alignment and backdrop-close

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -171,12 +171,17 @@ function onFullState(msg) {
     }
 }
 
+/* Hyper-V/HCS requires VM memory aligned to 2 MB, so RAM (MB) must be even;
+   round an odd value down by 1. (HCS enforces this — hcsshim's NormalizeMemorySize
+   does the same — and we call HCS directly, so we align here.) */
+function alignRamMb(mb) { return mb - (mb % 2); }
+
 function applySmartDefaults(info) {
     var ram = Math.min(Math.floor(info.hostRamMb / 2), 16384);
     var cores = Math.min(Math.floor(info.hostCores / 2), 8);
     if (ram < 512) ram = 512;
     if (cores < 1) cores = 1;
-    document.getElementById('ram-size').value = ram;
+    document.getElementById('ram-size').value = alignRamMb(ram);
     document.getElementById('cpu-cores').value = cores;
 }
 
@@ -354,6 +359,12 @@ document.getElementById('image-path').addEventListener('input', function() {
     updateCreateButtons();
 });
 
+/* RAM must be 2 MB-aligned: snap an odd entry down by 1 when the field is committed. */
+document.getElementById('ram-size').addEventListener('change', function() {
+    var mb = parseInt(this.value, 10);
+    if (!isNaN(mb)) this.value = alignRamMb(mb);
+});
+
 function revalidateVmName() {
     var name = document.getElementById('vm-name').value.trim();
     document.getElementById('vm-name-warn').textContent = validateVmName(name) || '';
@@ -423,7 +434,7 @@ function gatherConfig() {
         imagePath:   imagePath,
         templateName: document.getElementById('template-select').value,
         hddGb:       parseInt(document.getElementById('hdd-size').value) || 64,
-        ramMb:       parseInt(document.getElementById('ram-size').value) || 16384,
+        ramMb:       alignRamMb(parseInt(document.getElementById('ram-size').value) || 16384),
         cpuCores:    parseInt(document.getElementById('cpu-cores').value) || 8,
         gpuMode:     parseInt(document.getElementById('gpu-mode').value),
         networkMode: parseInt(document.getElementById('net-mode').value),
@@ -585,9 +596,17 @@ function closeCreateModal() {
     document.getElementById('create-vm-overlay').classList.remove('active');
 }
 
-/* Close on backdrop click */
+/* Close on backdrop click — but only when the press also STARTED on the backdrop.
+   A click targets the common ancestor of the mousedown and mouseup, so pressing
+   inside the modal (e.g. selecting text in a field) and releasing on the backdrop
+   would otherwise close it. */
+let createBackdropPress = false;
+document.getElementById('create-vm-overlay').addEventListener('mousedown', function(e) {
+    createBackdropPress = (e.target === this);
+});
 document.getElementById('create-vm-overlay').addEventListener('click', function(e) {
-    if (e.target === this) closeCreateModal();
+    if (e.target === this && createBackdropPress) closeCreateModal();
+    createBackdropPress = false;
 });
 
 /* Close on Escape */
@@ -961,6 +980,12 @@ function commitInlineEdit() {
     else if (col === 5) field = 'ramMb';
     else if (col === 7) field = 'gpuMode';
     else if (col === 8) field = 'networkMode';
+
+    /* RAM must be 2 MB-aligned (HCS requirement): round an odd entry down by 1. */
+    if (field === 'ramMb') {
+        var mb = parseInt(value, 10);
+        if (!isNaN(mb)) value = String(alignRamMb(mb));
+    }
 
     if (field) {
         sendCmd('editVm', { vmIndex: row, field: field, value: value });

--- a/web/index.html
+++ b/web/index.html
@@ -107,7 +107,7 @@
 
             <label for="ram-size">RAM Size:</label>
             <div class="form-row">
-                <input type="number" id="ram-size" value="16384" min="512" class="input-sm"> MB
+                <input type="number" id="ram-size" value="16384" min="512" step="2" class="input-sm"> MB
                 <span class="host-info" id="host-ram"></span>
             </div>
 


### PR DESCRIPTION
RAM (MB) must be 2 MB-aligned for Hyper-V/HCS, but the smart default (half of a 15982 MB host = 7991) and odd user-entered values were passed through unaligned and failed to boot. Round odd RAM down to even in the default, the create form (gatherConfig + a live field snap), and inline row edits; add step=2 on the field.

Also stop the New Sandbox modal from closing when a press starts inside it (e.g. selecting text in a field) and releases on the backdrop -- only close when the press also started on the backdrop.