### PR TITLE
Fix runaway WM_PAINT loop pegging the GPU on the IDD display window

### DIFF
--- a/src/backend_win/vm_display_idd.c
+++ b/src/backend_win/vm_display_idd.c
@@ -386,7 +386,15 @@ static LRESULT CALLBACK idd_render_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM l
     switch (msg) {
     case WM_ERASEBKGND:
         return 1;
-    case WM_PAINT:
+    case WM_PAINT: {
+        /* Validate this window's update region; repaint once for expose/resize
+           (rendering is otherwise push-driven by received frames). */
+        PAINTSTRUCT ps;
+        BeginPaint(hwnd, &ps);
+        EndPaint(hwnd, &ps);
+        SendMessageW(GetParent(hwnd), WM_IDD_FRAME_READY, 0, 0);
+        return 0;
+    }
     case WM_MOUSEMOVE:
     case WM_LBUTTONDOWN: case WM_LBUTTONUP:
     case WM_RBUTTONDOWN: case WM_RBUTTONUP:
@@ -1211,6 +1219,7 @@ static void d3d_render_frame(VmDisplayIdd *d)
     RECT rc;
     HRESULT hr;
     float clear_color[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+    BOOL frame_uploaded = FALSE;
 
     if (!d->device || !d->ctx || !d->swap_chain || !d->rtv)
         return;
@@ -1239,6 +1248,7 @@ static void d3d_render_frame(VmDisplayIdd *d)
         }
         d->frame_dirty = FALSE;
         LeaveCriticalSection(&d->frame_cs);
+        frame_uploaded = TRUE;
     }
 
     /* Compute letterboxed viewport within client area */
@@ -1256,7 +1266,8 @@ static void d3d_render_frame(VmDisplayIdd *d)
         vp.MaxDepth = 1.0f;
     }
 
-    if (d->render_count % 60 == 0 && d->hwnd) {
+    /* Refresh the title once per uploaded frame (~frame rate). */
+    if (frame_uploaded && d->hwnd) {
         wchar_t title[256];
         swprintf_s(title, 256, L"%s%s Display %ux%u recv=%u",
                    d->audio_muted ? L"\U0001F507 " : L"",


### PR DESCRIPTION
The IDD render child window (AppSandboxIddRender) forwarded WM_PAINT to its parent along with the input messages. The parent's WM_PAINT handler calls BeginPaint/EndPaint on the parent, never on the child, so the child's update region was never validated. Windows therefore re-issued WM_PAINT to the child on every message-pump idle, driving d3d_render_frame -> Present ~2,100 times a second and pegging the host GPU 3D engine at ~90% for a trivial full-screen textured quad (~0.36 ms of GPU work per present; the defect is the present count, not the per-present cost).

Give the render child its own WM_PAINT case that validates its update region with BeginPaint/EndPaint and requests a single repaint via WM_IDD_FRAME_READY, so expose/resize still repaints. Rendering is otherwise push-driven by received frames plus a dirty-gated 16 ms backstop timer, so no continuous stream is needed. Present rate drops to the real frame rate (~30-60/s) and the GPU falls off the ceiling. SyncInterval stays 0, so latency is unchanged (no swap-chain, flip-model, or vsync changes).

Re-gate the window-title recv= counter in d3d_render_frame on a per-uploaded- frame flag instead of render_count % 60. With renders no longer running at ~2,100/s, "every 60 renders" updated the title only every 1-2 seconds; gating on actual uploaded frames keeps it ticking at ~frame rate.