### PR TITLE
iso-patch: force English DISM output for ISO language detection (fixes #84)

### DIFF
--- a/tools/iso-patch/iso-patch.c
+++ b/tools/iso-patch/iso-patch.c
@@ -847,7 +847,7 @@ static int do_to_vhdx(const wchar_t *iso_path_arg, int image_index, int size_gb,
         const char *detected_lang = "en-US";  /* fallback */
         GetSystemDirectoryW(sys_dir, MAX_PATH);
         swprintf_s(dism_cmd, 1024,
-            L"%s\\dism.exe /Get-WimInfo /WimFile:\"%s\" /Index:%d",
+            L"%s\\dism.exe /English /Get-WimInfo /WimFile:\"%s\" /Index:%d",
             sys_dir, wim_path, image_index);
         if (run_command_capture(dism_cmd, dism_output, sizeof(dism_output)) == 0) {
             /* Look for "xx-YY (Default)" pattern in DISM output */


### PR DESCRIPTION
## Problem

The Windows ISO language detection (`tools/iso-patch/iso-patch.c`, Step 2.5) parses `dism /Get-WimInfo` output looking for the literal string `"(Default)"`. DISM localizes its output to the **host** UI language, so on any non-English host the marker never matches — French DISM prints `(Par défaut)`, Korean prints `(기본값)`, etc. Detection then silently falls back to `en-US` regardless of the ISO's actual language, and the guest is provisioned with an `en-US` unattend: wrong UI language, wrong keyboard layout (e.g. QWERTY on a French fr-FR ISO).

This is exactly what #84 reports (`Detected ISO language: en-US` for a Korean ISO from the official Microsoft page).

## Fix

Pass DISM's documented global `/English` switch so the output is always in English and the `"(Default)"` pattern matches on every host locale:

```
dism.exe /English /Get-WimInfo /WimFile:"..." /Index:N
```

Failure behavior is unchanged: if the pattern is still absent for any reason, the code falls back to `en-US` exactly as before.

## Testing

Rebuilt `iso-patch.exe` (MSBuild, Release x64) on a **French** Windows 11 host and created a VM from a French `Win11_25H2_French_x64_v2.iso`:
- Before: `Detected ISO language: en-US` → guest installs with en-US locale + US keyboard.
- After: the language is detected correctly and the guest gets the matching unattend (fr-FR locale, AZERTY layout).

Fixes #84
