### PR TITLE
create: reject username equal to the VM name for Windows guests (#87)

### DIFF
--- a/src/app_mac/headless.m
+++ b/src/app_mac/headless.m
@@ -372,6 +372,12 @@ static NSString *validate_create_mac(NSString *name, NSString *os,
         @"LPT1",@"LPT2",@"LPT3",@"LPT4",@"LPT5",@"LPT6",@"LPT7",@"LPT8",@"LPT9"];
     if ([reserved containsObject:user.uppercaseString])
         return @"Username is a reserved name.";
+    /* Windows guests: the VM name becomes the guest ComputerName; a user named
+       like the machine cannot be added to local groups during the unattend pass
+       (ERROR_NO_SUCH_MEMBER), so the account ends up group-less and the agent
+       never installs. */
+    if (is_win && [user caseInsensitiveCompare:name] == NSOrderedSame)
+        return @"Username cannot be the same as the VM name.";
 
     /* numeric ranges (0 = unset -> the core fills a default). The even-RAM
        rule is kept for interface parity with the GUI/Windows daemon. */

--- a/src/app_win/headless.c
+++ b/src/app_win/headless.c
@@ -535,6 +535,12 @@ static const char *validate_create(const wchar_t *name, const wchar_t *os,
                 int r; for (r = 0; r < (int)(sizeof(res)/sizeof(res[0])); r++)
                     if (_wcsicmp(user, res[r]) == 0) return "Username is a reserved name.";
             }
+            /* The VM name becomes the guest ComputerName; a user named like
+               the machine cannot be added to local groups during the unattend
+               pass (ERROR_NO_SUCH_MEMBER), so the account ends up group-less
+               and the agent never installs. */
+            if (_wcsicmp(user, name) == 0)
+                return "Username cannot be the same as the VM name.";
         }
         if (is_linux) {
             if (!pass || !pass[0]) return "Password is required.";

--- a/web/app.js
+++ b/web/app.js
@@ -378,6 +378,8 @@ function revalidateVmName() {
     document.getElementById('vm-name-warn').textContent = validateVmName(name) || '';
 }
 document.getElementById('vm-name').addEventListener('input', revalidateVmName);
+/* Username validity depends on the VM name (Windows: username != VM name). */
+document.getElementById('vm-name').addEventListener('input', revalidateUsername);
 
 function revalidateUsername() {
     var u = document.getElementById('admin-user').value.trim();
@@ -524,6 +526,18 @@ function validateUsername(name) {
         'COM1','COM2','COM3','COM4','COM5','COM6','COM7','COM8','COM9',
         'LPT1','LPT2','LPT3','LPT4','LPT5','LPT6','LPT7','LPT8','LPT9'];
     if (reserved.indexOf(name.toUpperCase()) >= 0) return 'Username is a reserved name.';
+    /* Windows guests: the VM name becomes the guest ComputerName, and a user
+       named like the machine cannot be added to local groups during the
+       unattend pass (LookupAccountName resolves the machine object first,
+       NetLocalGroupAddMembers fails with ERROR_NO_SUCH_MEMBER). The account
+       ends up group-less, OOBE autologs defaultuser0 instead and the agent
+       never installs. */
+    if (osType === 'Windows') {
+        var vmNameEl = document.getElementById('vm-name');
+        var vmName = vmNameEl ? vmNameEl.value.trim() : '';
+        if (vmName && name.toLowerCase() === vmName.toLowerCase())
+            return 'Username cannot be the same as the VM name.';
+    }
     return null;
 }
 


### PR DESCRIPTION
## Problem

Creating a Windows VM whose **admin username is identical to the VM name** (e.g. VM `test`, user `test`) always ends up stuck on "Installing Windows" with the agent never coming online (and therefore no mouse/keyboard in the display).

Root cause chain, diagnosed by mounting the guest VHDX and reading `C:\Windows\Panther\UnattendGC\setupact.log`:

1. The VM name becomes the guest `ComputerName` (`asb_provision_unattend`).
2. During the unattend `UserAccounts` pass, the account is created, but adding it to local groups fails: `LookupAccountName` on a machine named like the user resolves the computer/domain object first, so `NetLocalGroupAddMembers` fails with `ERROR_NO_SUCH_MEMBER`:
   ```
   [Shell Unattend] UserAccounts: created account 'test'
   [Shell Unattend] UserAccounts: failed to add 'test' to group 'Utilisateurs' (0x8007056b)
   [Shell Unattend] UserAccounts: failed to add 'test' to group 'Administrateurs' (0x8007056b)
   ```
3. The account ends up in **no group at all**, so msoobe decides no usable local account exists, creates `defaultuser0` and autologs that instead (`Creating a new default account` / `Not setting autologon for new local user`).
4. `FirstLogonCommands` tied to the created user never run → `setup.cmd` → `appsandbox-agent.exe --install` never execute → the agent never connects and `install_complete` stays false forever.

Meanwhile `SetupComplete.cmd` *does* run (as SYSTEM), so the VDD comes up and the display opens — "display works, agent never online" is the signature of this failure. This is very likely the root cause of the Windows reports in #87.

## Fix

Reject the collision at creation time, in the three places input is validated:

- `web/app.js` `validateUsername` (GUI, both hosts) — Windows guests only, case-insensitive; also revalidate the username live when the VM name field changes.
- `src/app_win/headless.c` `validate_create` (Windows daemon) — same rule in the Windows-account branch.
- `src/app_mac/headless.m` `validate_create_mac` (macOS daemon) — Windows guests only.

Error message in all three: `Username cannot be the same as the VM name.`

## Testing

- Reproduced the failure with VM `test` / user `test` (Win11 25H2 guest): agent never installs, guest log shows the `0x8007056b` group-add failures above.
- Recreated the same VM with user `testuser`: install completes, agent comes online, everything works.
- `src/app_win/headless.c` compiles cleanly with the change (MSBuild, Release x64).

Likely fixes the Windows cases of #87
