### PR TITLE
feat: added borderless fullscreen option with F11 toggle

### DIFF
--- a/src/app_mac/AppDelegate.m
+++ b/src/app_mac/AppDelegate.m
@@ -62,6 +62,22 @@
     logItem.target = self;
     logItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
     [viewItem.submenu addItem:logItem];
+
+    NSMenuItem *borderlessItem = [[NSMenuItem alloc]
+        initWithTitle:@"Toggle Borderless Full Screen"
+               action:@selector(toggleBorderlessFullscreen:)
+        keyEquivalent:[NSString stringWithFormat:@"%C", NSF11FunctionKey]];
+    borderlessItem.target = self;
+    [viewItem.submenu addItem:borderlessItem];
+}
+
+- (void)toggleBorderlessFullscreen:(id)sender {
+    id controller = NSApp.keyWindow.windowController;
+    if (controller && [controller respondsToSelector:_cmd]) {
+        [controller toggleBorderlessFullscreen:sender];
+    } else {
+        [self.mainWindowController toggleBorderlessFullscreen:sender];
+    }
 }
 
 - (void)toggleEventLog:(id)sender {

--- a/src/app_mac/MainWindowController.h
+++ b/src/app_mac/MainWindowController.h
@@ -3,4 +3,5 @@
 
 @interface MainWindowController : NSWindowController <WKNavigationDelegate, WKScriptMessageHandler>
 @property (nonatomic, strong) WKWebView *webView;
+- (void)toggleBorderlessFullscreen:(id)sender;
 @end

--- a/src/app_mac/MainWindowController.m
+++ b/src/app_mac/MainWindowController.m
@@ -1,6 +1,12 @@
 #import "MainWindowController.h"
 #import "ui.h"
 
+@interface MainWindowController ()
+@property (nonatomic) BOOL borderlessFullscreen;
+@property (nonatomic) NSWindowStyleMask windowedStyleMask;
+@property (nonatomic) NSRect windowedFrame;
+@end
+
 @implementation MainWindowController
 
 - (instancetype)init {
@@ -51,6 +57,23 @@
     (void)userContentController;
     if ([message.body isKindOfClass:[NSString class]]) {
         ui_handle_message((NSString *)message.body);
+    }
+}
+
+- (void)toggleBorderlessFullscreen:(id)sender {
+    (void)sender;
+    NSWindow *window = self.window;
+
+    if (!self.borderlessFullscreen) {
+        self.windowedStyleMask = window.styleMask;
+        self.windowedFrame = window.frame;
+        window.styleMask = NSWindowStyleMaskBorderless;
+        [window setFrame:window.screen.frame display:YES];
+        self.borderlessFullscreen = YES;
+    } else {
+        window.styleMask = self.windowedStyleMask;
+        [window setFrame:self.windowedFrame display:YES];
+        self.borderlessFullscreen = NO;
     }
 }
 

--- a/src/app_win/ui.c
+++ b/src/app_win/ui.c
@@ -42,6 +42,11 @@ static int g_selected_vm = -1;
 static int g_min_width = 0;
 static int g_min_height = 0;
 
+/* Borderless fullscreen state. */
+static BOOL g_borderless_fullscreen = FALSE;
+static LONG_PTR g_windowed_style = 0;
+static WINDOWPLACEMENT g_windowed_placement = { sizeof(WINDOWPLACEMENT) };
+
 /* Display windows (indexed parallel to the library's VM array) */
 static VmDisplay *g_displays[ASB_MAX_VMS];
 static VmDisplayIdd *g_idd_displays[ASB_MAX_VMS];
@@ -101,6 +106,42 @@ static void send_vm_list(void);
 static void send_full_state(void);
 static void send_adapters(void);
 static void send_templates(void);
+static void toggle_borderless_fullscreen(HWND hwnd);
+static void on_webview2_accelerator(UINT virtual_key);
+
+static void toggle_borderless_fullscreen(HWND hwnd)
+{
+    if (!g_borderless_fullscreen) {
+        MONITORINFO monitor = { sizeof(monitor) };
+        HMONITOR hmonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+
+        if (!GetWindowPlacement(hwnd, &g_windowed_placement) ||
+            !GetMonitorInfoW(hmonitor, &monitor))
+            return;
+
+        g_windowed_style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+        SetWindowLongPtrW(hwnd, GWL_STYLE,
+                          (g_windowed_style & ~WS_OVERLAPPEDWINDOW) | WS_POPUP);
+        SetWindowPos(hwnd, HWND_TOP, monitor.rcMonitor.left, monitor.rcMonitor.top,
+                     monitor.rcMonitor.right - monitor.rcMonitor.left,
+                     monitor.rcMonitor.bottom - monitor.rcMonitor.top,
+                     SWP_FRAMECHANGED | SWP_NOOWNERZORDER);
+        g_borderless_fullscreen = TRUE;
+    } else {
+        SetWindowLongPtrW(hwnd, GWL_STYLE, g_windowed_style);
+        SetWindowPos(hwnd, NULL, 0, 0, 0, 0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
+                     SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
+        SetWindowPlacement(hwnd, &g_windowed_placement);
+        g_borderless_fullscreen = FALSE;
+    }
+}
+
+static void on_webview2_accelerator(UINT virtual_key)
+{
+    if (virtual_key == VK_F11 && g_hwnd_main)
+        toggle_borderless_fullscreen(g_hwnd_main);
+}
 
 /* ---- Safe display teardown ---- */
 
@@ -1244,6 +1285,7 @@ static LRESULT CALLBACK main_wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
         vm_agent_set_hwnd(hwnd);
         asb_idd_probe_set_hwnd(hwnd);
         webview2_set_message_callback(on_webview2_message);
+        webview2_set_accelerator_callback(on_webview2_accelerator);
         if (!webview2_init(hwnd, g_hInstance)) {
             MessageBoxW(hwnd, L"WebView2 initialization failed.\nPlease install Microsoft Edge WebView2 Runtime.",
                         L"App Sandbox", MB_ICONERROR);
@@ -1254,6 +1296,13 @@ static LRESULT CALLBACK main_wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_SIZE:
         webview2_resize(hwnd);
         return 0;
+
+    case WM_KEYDOWN:
+        if (wp == VK_F11 && !(lp & (1L << 30))) {
+            toggle_borderless_fullscreen(hwnd);
+            return 0;
+        }
+        break;
 
     case WM_MEASUREITEM:
         if (((MEASUREITEMSTRUCT *)lp)->CtlType == ODT_MENU) {

--- a/src/app_win/webview2_bridge.c
+++ b/src/app_win/webview2_bridge.c
@@ -50,9 +50,14 @@ static int g_queue_count;
 /* ---- Forward declarations ---- */
 
 static WebView2MessageCallback g_message_callback;
+static WebView2AcceleratorCallback g_accelerator_callback;
 
 void webview2_set_message_callback(WebView2MessageCallback cb) {
     g_message_callback = cb;
+}
+
+void webview2_set_accelerator_callback(WebView2AcceleratorCallback cb) {
+    g_accelerator_callback = cb;
 }
 
 /* ---- COM callback: Environment Created ---- */
@@ -169,6 +174,64 @@ static ICoreWebView2WebMessageReceivedEventHandlerVtbl g_msgVtbl = {
     MsgH_QI, MsgH_AddRef, MsgH_Release, MsgH_Invoke
 };
 
+/* ---- COM callback: Accelerator Key Pressed ---- */
+
+typedef struct {
+    ICoreWebView2AcceleratorKeyPressedEventHandlerVtbl *lpVtbl;
+    LONG ref;
+} AcceleratorHandler;
+
+static HRESULT STDMETHODCALLTYPE AcceleratorH_QI(
+    ICoreWebView2AcceleratorKeyPressedEventHandler *This, REFIID riid, void **ppv)
+{
+    if (IsEqualIID(riid, &IID_IUnknown) ||
+        IsEqualIID(riid, &IID_ICoreWebView2AcceleratorKeyPressedEventHandler)) {
+        *ppv = This;
+        This->lpVtbl->AddRef(This);
+        return S_OK;
+    }
+    *ppv = NULL;
+    return E_NOINTERFACE;
+}
+static ULONG STDMETHODCALLTYPE AcceleratorH_AddRef(
+    ICoreWebView2AcceleratorKeyPressedEventHandler *This)
+{
+    return InterlockedIncrement(&((AcceleratorHandler *)This)->ref);
+}
+static ULONG STDMETHODCALLTYPE AcceleratorH_Release(
+    ICoreWebView2AcceleratorKeyPressedEventHandler *This)
+{
+    LONG ref = InterlockedDecrement(&((AcceleratorHandler *)This)->ref);
+    if (ref == 0) free(This);
+    return ref;
+}
+static HRESULT STDMETHODCALLTYPE AcceleratorH_Invoke(
+    ICoreWebView2AcceleratorKeyPressedEventHandler *This,
+    ICoreWebView2Controller *sender,
+    ICoreWebView2AcceleratorKeyPressedEventArgs *args)
+{
+    UINT key = 0;
+    COREWEBVIEW2_KEY_EVENT_KIND kind;
+    INT lparam = 0;
+    (void)This;
+    (void)sender;
+
+    if (SUCCEEDED(args->lpVtbl->get_VirtualKey(args, &key)) &&
+        SUCCEEDED(args->lpVtbl->get_KeyEventKind(args, &kind)) &&
+        SUCCEEDED(args->lpVtbl->get_KeyEventLParam(args, &lparam)) &&
+        key == VK_F11 && kind == COREWEBVIEW2_KEY_EVENT_KIND_KEY_DOWN &&
+        !(lparam & (1 << 30))) {
+        args->lpVtbl->put_Handled(args, TRUE);
+        if (g_accelerator_callback)
+            g_accelerator_callback(key);
+    }
+    return S_OK;
+}
+
+static ICoreWebView2AcceleratorKeyPressedEventHandlerVtbl g_acceleratorVtbl = {
+    AcceleratorH_QI, AcceleratorH_AddRef, AcceleratorH_Release, AcceleratorH_Invoke
+};
+
 /* ---- Callback implementations ---- */
 
 static HRESULT STDMETHODCALLTYPE EnvH_Invoke(
@@ -200,6 +263,7 @@ static HRESULT STDMETHODCALLTYPE CtrlH_Invoke(
     ICoreWebView2 *webview = NULL;
     ICoreWebView2Settings *settings = NULL;
     MsgHandler *mh;
+    AcceleratorHandler *ah;
     EventRegistrationToken token;
     wchar_t html_path[MAX_PATH];
     wchar_t url[MAX_PATH + 16];
@@ -238,6 +302,15 @@ static HRESULT STDMETHODCALLTYPE CtrlH_Invoke(
         mh->ref = 1;
         webview->lpVtbl->add_WebMessageReceived(webview,
             (ICoreWebView2WebMessageReceivedEventHandler *)mh, &token);
+    }
+
+    ah = (AcceleratorHandler *)calloc(1, sizeof(AcceleratorHandler));
+    if (ah) {
+        ah->lpVtbl = &g_acceleratorVtbl;
+        ah->ref = 1;
+        controller->lpVtbl->add_AcceleratorKeyPressed(controller,
+            (ICoreWebView2AcceleratorKeyPressedEventHandler *)ah, &token);
+        ah->lpVtbl->Release((ICoreWebView2AcceleratorKeyPressedEventHandler *)ah);
     }
 
     /* Resize to fill parent */

--- a/src/app_win/webview2_bridge.h
+++ b/src/app_win/webview2_bridge.h
@@ -27,6 +27,10 @@ BOOL webview2_is_ready(void);
 typedef void (*WebView2MessageCallback)(const wchar_t *json);
 void webview2_set_message_callback(WebView2MessageCallback cb);
 
+/* Set callback for accelerator keys handled by the native window. */
+typedef void (*WebView2AcceleratorCallback)(UINT virtual_key);
+void webview2_set_accelerator_callback(WebView2AcceleratorCallback cb);
+
 /* ---- JSON builder helpers ---- */
 
 typedef struct {

--- a/src/backend_mac/idd_display.h
+++ b/src/backend_mac/idd_display.h
@@ -36,5 +36,6 @@
 - (instancetype)initWithName:(NSString *)name
                    transport:(AsbIvshmemTransport *)transport;
 - (void)showDisplay;
+- (void)toggleBorderlessFullscreen:(id)sender;
 
 @end

--- a/src/backend_mac/idd_display.m
+++ b/src/backend_mac/idd_display.m
@@ -252,6 +252,9 @@ static NSCursor *buildGuestCursor(AsbCursor *cur, double scale)
 @property (nonatomic, strong) AsbIvshmemTransport *transport;
 @property (nonatomic, strong) IddDisplayView *view;
 @property (nonatomic, strong) NSTimer *timer;
+@property (nonatomic) BOOL borderlessFullscreen;
+@property (nonatomic) NSWindowStyleMask windowedStyleMask;
+@property (nonatomic) NSRect windowedFrame;
 
 /* ch2/ch3/ch4/ch5/ch6 reader loops, run on pthreads via the C trampolines below. */
 - (void)displayLoop;
@@ -488,6 +491,23 @@ static NSCursor *buildGuestCursor(AsbCursor *cur, double scale)
         _surfTex[i] = [_mtlDev newTextureWithDescriptor:td iosurface:_surf[i] plane:0];
     }
     _surfW = w; _surfH = h; _frontValid = NO; _frontIdx = 0;
+}
+
+- (void)toggleBorderlessFullscreen:(id)sender {
+    (void)sender;
+    NSWindow *window = self.window;
+
+    if (!self.borderlessFullscreen) {
+        self.windowedStyleMask = window.styleMask;
+        self.windowedFrame = window.frame;
+        window.styleMask = NSWindowStyleMaskBorderless;
+        [window setFrame:window.screen.frame display:YES];
+        self.borderlessFullscreen = YES;
+    } else {
+        window.styleMask = self.windowedStyleMask;
+        [window setFrame:self.windowedFrame display:YES];
+        self.borderlessFullscreen = NO;
+    }
 }
 
 - (void)showDisplay {

--- a/src/backend_mac/vz_display.h
+++ b/src/backend_mac/vz_display.h
@@ -16,5 +16,6 @@
 
 - (instancetype)initWithVzVm:(VzVm *)vm;
 - (void)showDisplay;
+- (void)toggleBorderlessFullscreen:(id)sender;
 
 @end

--- a/src/backend_mac/vz_display.m
+++ b/src/backend_mac/vz_display.m
@@ -5,6 +5,9 @@
 @interface VzDisplayWindow () <NSWindowDelegate>
 @property (nonatomic, strong) VzVm *vm;
 @property (nonatomic, strong) VZVirtualMachineView *vmView;
+@property (nonatomic) BOOL borderlessFullscreen;
+@property (nonatomic) NSWindowStyleMask windowedStyleMask;
+@property (nonatomic) NSRect windowedFrame;
 @end
 
 @implementation VzDisplayWindow
@@ -32,6 +35,23 @@
     window.contentView = _vmView;
     window.delegate = self;
     return self;
+}
+
+- (void)toggleBorderlessFullscreen:(id)sender {
+    (void)sender;
+    NSWindow *window = self.window;
+
+    if (!self.borderlessFullscreen) {
+        self.windowedStyleMask = window.styleMask;
+        self.windowedFrame = window.frame;
+        window.styleMask = NSWindowStyleMaskBorderless;
+        [window setFrame:window.screen.frame display:YES];
+        self.borderlessFullscreen = YES;
+    } else {
+        window.styleMask = self.windowedStyleMask;
+        [window setFrame:self.windowedFrame display:YES];
+        self.borderlessFullscreen = NO;
+    }
 }
 
 - (void)showDisplay {

--- a/src/backend_win/vm_display_idd.c
+++ b/src/backend_win/vm_display_idd.c
@@ -210,6 +210,9 @@ struct VmDisplayIdd {
     HWND         hwnd;
     volatile BOOL open;
     volatile BOOL stop;
+    BOOL          borderless_fullscreen;
+    LONG_PTR      windowed_style;
+    WINDOWPLACEMENT windowed_placement;
 
     /* D3D11 */
     ID3D11Device            *device;
@@ -278,6 +281,7 @@ struct VmDisplayIdd {
 static LRESULT CALLBACK idd_wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp);
 static DWORD WINAPI     idd_window_thread_proc(LPVOID param);
 static DWORD WINAPI     idd_recv_thread_proc(LPVOID param);
+static void             idd_toggle_borderless_fullscreen(VmDisplayIdd *d, HWND hwnd);
 
 /* ---- Window class ---- */
 
@@ -289,6 +293,7 @@ static const wchar_t *IDD_LOG_CLASS     = L"AppSandboxIddLog";
 #define IDM_AUDIO_MUTE     0x1000
 #define IDM_XMIT_HOTKEYS   0x1010
 #define IDM_SHOW_LOG       0x1020
+#define IDM_BORDERLESS_FULLSCREEN 0x1030
 static BOOL g_idd_class_registered;
 static WNDPROC g_orig_listbox_proc;
 
@@ -1908,6 +1913,7 @@ static DWORD WINAPI idd_window_thread_proc(LPVOID param)
             AppendMenuW(sysmenu, MF_SEPARATOR, 0, NULL);
             AppendMenuW(sysmenu, MF_STRING, IDM_AUDIO_MUTE, L"Mute audio");
             AppendMenuW(sysmenu, MF_STRING, IDM_XMIT_HOTKEYS, L"Transmit Keyboard Hotkeys");
+            AppendMenuW(sysmenu, MF_STRING, IDM_BORDERLESS_FULLSCREEN, L"Toggle Borderless Fullscreen\tF11");
             AppendMenuW(sysmenu, MF_STRING, IDM_SHOW_LOG, L"Show Log");
             CheckMenuItem(sysmenu, IDM_XMIT_HOTKEYS,
                           MF_BYCOMMAND | (d->transmit_hotkeys ? MF_CHECKED : MF_UNCHECKED));
@@ -2014,6 +2020,46 @@ static DWORD WINAPI idd_window_thread_proc(LPVOID param)
  * Window procedure
  * ================================================================== */
 
+static void idd_toggle_borderless_fullscreen(VmDisplayIdd *d, HWND hwnd)
+{
+    HMENU sysmenu;
+
+    if (!d->borderless_fullscreen) {
+        MONITORINFO monitor = { sizeof(monitor) };
+        HMONITOR hmonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+
+        d->windowed_placement.length = sizeof(d->windowed_placement);
+        if (!GetWindowPlacement(hwnd, &d->windowed_placement) ||
+            !GetMonitorInfoW(hmonitor, &monitor))
+            return;
+
+        d->windowed_style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+        SetWindowLongPtrW(hwnd, GWL_STYLE,
+                          (d->windowed_style & ~WS_OVERLAPPEDWINDOW) | WS_POPUP);
+        SetWindowPos(hwnd, HWND_TOP, monitor.rcMonitor.left, monitor.rcMonitor.top,
+                     monitor.rcMonitor.right - monitor.rcMonitor.left,
+                     monitor.rcMonitor.bottom - monitor.rcMonitor.top,
+                     SWP_FRAMECHANGED | SWP_NOOWNERZORDER);
+        d->borderless_fullscreen = TRUE;
+    } else {
+        SetWindowLongPtrW(hwnd, GWL_STYLE, d->windowed_style);
+        SetWindowPlacement(hwnd, &d->windowed_placement);
+        SetWindowPos(hwnd, NULL, 0, 0, 0, 0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
+                     SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
+        d->borderless_fullscreen = FALSE;
+    }
+
+    sysmenu = GetSystemMenu(hwnd, FALSE);
+    if (sysmenu) {
+        CheckMenuItem(sysmenu, IDM_BORDERLESS_FULLSCREEN,
+                      MF_BYCOMMAND | (d->borderless_fullscreen ? MF_CHECKED : MF_UNCHECKED));
+    }
+    idd_log(d, d->borderless_fullscreen
+                   ? L"Borderless fullscreen: ON."
+                   : L"Borderless fullscreen: OFF.");
+}
+
 static LRESULT CALLBACK idd_wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     VmDisplayIdd *d;
@@ -2029,6 +2075,10 @@ static LRESULT CALLBACK idd_wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
 
     switch (msg) {
     case WM_SYSCOMMAND:
+        if (d && (wp & 0xFFF0) == IDM_BORDERLESS_FULLSCREEN) {
+            idd_toggle_borderless_fullscreen(d, hwnd);
+            return 0;
+        }
         if (d && (wp & 0xFFF0) == IDM_AUDIO_MUTE) {
             HMENU sysmenu = GetSystemMenu(hwnd, FALSE);
             wchar_t title[300];
@@ -2338,6 +2388,12 @@ static LRESULT CALLBACK idd_wnd_proc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_SYSKEYUP:
     {
         UINT32 scan = (UINT32)((lp >> 16) & 0xFF);
+        if (wp == VK_F11) {
+            if ((msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN) &&
+                !(lp & (1L << 30)) && d)
+                idd_toggle_borderless_fullscreen(d, hwnd);
+            return 0;  /* Never forward F11 to the guest. */
+        }
         BOOL ext = (lp & (1 << 24)) != 0;
         BOOL up  = (msg == WM_KEYUP || msg == WM_SYSKEYUP);
         if (!d) break;


### PR DESCRIPTION
## Add borderless fullscreen support for VM display windows

This change adds an F11-driven borderless fullscreen mode for VM display windows across Windows and macOS.

### What changed

- Windows IDD display
  - Adds `Toggle Borderless Fullscreen (F11)` to the display window system menu.
  - Handles F11 directly in the IDD display window.
  - Prevents F11 from being forwarded to the guest.
  - Restores the previous window style and placement when toggled off.

- macOS display windows
  - Adds borderless fullscreen support to both:
    - `IddDisplayWindow` for Windows guests.
    - `VzDisplayWindow` for macOS guests.
  - Updates the app’s F11 menu action to target the currently active display window, instead of only the main application window.

- Main application windows
  - Retains the existing borderless fullscreen action for the main GUI on Windows and macOS.

### User experience

Users can press F11 while a VM display window is active to switch between windowed mode and borderless fullscreen. On Windows, the same action is also available from the IDD display window’s system menu.