### PR TITLE
Windows: report free space of the volume backing the VM data directory

### DIFF
--- a/src/app_win/headless.c
+++ b/src/app_win/headless.c
@@ -266,12 +266,17 @@ static int append_vm_json(char *out, int cap, int pos, VmInstance *v)
 static int build_host_info(char *buf, int cap)
 {
     SYSTEM_INFO si; MEMORYSTATUSEX ms; ULARGE_INTEGER freeB;
-    wchar_t pd[MAX_PATH];
+    wchar_t pd[MAX_PATH], vm_dir[MAX_PATH];
     int i, count, vmCores = 0, vmRamMb = 0, vmHddGb = 0;
     GetSystemInfo(&si);
     ms.dwLength = sizeof(ms); GlobalMemoryStatusEx(&ms);
-    if (!GetEnvironmentVariableW(L"ProgramData", pd, MAX_PATH)) wcscpy_s(pd, MAX_PATH, L"C:\\");
-    freeB.QuadPart = 0; GetDiskFreeSpaceExW(pd, &freeB, NULL, NULL);
+    /* Free space on the volume backing %ProgramData%\AppSandbox (follows a
+       junction when VM storage was redirected); fall back to the root. */
+    if (!GetEnvironmentVariableW(L"ProgramData", pd, MAX_PATH)) wcscpy_s(pd, MAX_PATH, L"C:\\ProgramData");
+    swprintf_s(vm_dir, MAX_PATH, L"%s\\AppSandbox", pd);
+    freeB.QuadPart = 0;
+    if (!GetDiskFreeSpaceExW(vm_dir, &freeB, NULL, NULL))
+        GetDiskFreeSpaceExW(pd, &freeB, NULL, NULL);
     count = asb_vm_count();
     for (i = 0; i < count; i++) {
         VmInstance *v = asb_vm_instance(asb_vm_get(i));

--- a/src/app_win/ui.c
+++ b/src/app_win/ui.c
@@ -131,7 +131,7 @@ static void build_host_info_json(JsonBuilder *jb)
     MEMORYSTATUSEX ms;
     DWORD host_cores, host_ram_mb;
     DWORD vm_cores = 0, vm_ram_mb = 0, vm_hdd_gb = 0;
-    wchar_t base_dir[MAX_PATH];
+    wchar_t base_dir[MAX_PATH], vm_dir[MAX_PATH];
     ULARGE_INTEGER free_bytes;
     DWORD free_gb = 0;
     int i, count = asb_vm_count();
@@ -148,9 +148,16 @@ static void build_host_info_json(JsonBuilder *jb)
         if (v) vm_hdd_gb += v->hdd_gb;
     }
 
+    /* Report free space on the volume that actually backs the VM data
+       directory (%ProgramData%\AppSandbox), not the %ProgramData% root.
+       Querying the leaf directory lets GetDiskFreeSpaceEx follow a junction /
+       mount point when the user has redirected VM storage to another drive.
+       Fall back to the root when the directory does not exist yet. */
     if (!GetEnvironmentVariableW(L"ProgramData", base_dir, MAX_PATH))
         wcscpy_s(base_dir, MAX_PATH, L"C:\\ProgramData");
-    if (GetDiskFreeSpaceExW(base_dir, &free_bytes, NULL, NULL))
+    swprintf_s(vm_dir, MAX_PATH, L"%s\\AppSandbox", base_dir);
+    if (GetDiskFreeSpaceExW(vm_dir, &free_bytes, NULL, NULL) ||
+        GetDiskFreeSpaceExW(base_dir, &free_bytes, NULL, NULL))
         free_gb = (DWORD)(free_bytes.QuadPart / (1024ULL * 1024 * 1024));
 
     jb_int(jb, L"hostCores", (int)host_cores);


### PR DESCRIPTION
## Problem

On Windows, the New Sandbox dialog (`Free: N GB | VMs allocated: ...`) and the headless `/host` endpoint (`freeGb`) compute free space from the `%ProgramData%` root. VMs are actually stored under `%ProgramData%\AppSandbox`.

Users with a small `C:` commonly redirect that directory to another drive with a junction (`mklink /J C:\ProgramData\AppSandbox D:\AppSandboxData`). VHDX files then land on `D:`, but the UI keeps showing the free space of `C:`, which is misleading when sizing a new sandbox.

Before (VM storage junctioned to `D:`, 155 GB free):

| Path queried | Reported free |
|---|---|
| `C:\ProgramData` (current code) | 11 GB |
| `C:\ProgramData\AppSandbox` (this PR) | 155 GB |
| `D:\` | 155 GB |

## Change

- `src/app_win/ui.c` (`build_host_info_json`) and `src/app_win/headless.c` (`build_host_info`): query `%ProgramData%\AppSandbox` so `GetDiskFreeSpaceExW` resolves the reparse point, and fall back to the `%ProgramData%` root when the directory does not exist yet (fresh install).
- Also aligns the headless fallback path with `ui.c` (`C:\ProgramData` instead of `C:\`).

This matches the macOS backend, whose `HostInfo.freeGb` already reports "free bytes on the volume that backs the VMs root directory".

## Testing

- Built `AppSandbox.sln` Release|x64 with MSBuild (VS 2026 Community); compiles clean apart from the pre-existing `DwmSetWindowAttribute` warning in `vm_display_idd.c`.
- Verified with a P/Invoke call to `GetDiskFreeSpaceExW` on a host where `C:\ProgramData\AppSandbox` is a junction to `D:` (table above).
- No behaviour change on a default install (no junction): the leaf directory is on the same volume as the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
