### PR TITLE
iso-patch: fail loudly when the Ubuntu ISO's minimal.squashfs has no kernel (refs #66)

### DIFF
--- a/src/backend_win/asb_core.c
+++ b/src/backend_win/asb_core.c
@@ -2119,11 +2119,19 @@ static HRESULT run_iso_patch_ubuntu(const wchar_t *iso_path,
                             if (g_progress_cb && pvm)
                                 g_progress_cb(vm_handle(pvm), pct, is_staging, g_progress_ud);
                         } else if (strncmp(line, "ERROR:", 6) == 0) {
+                            asb_log(L"iso-patch: ERROR: %S", line + 6);
                             if (error_msg && error_msg[0] == L'\0')
                                 MultiByteToWideChar(CP_ACP, 0, line + 6, -1, error_msg, (int)error_msg_cap);
                             result = E_FAIL;
                         } else if (strncmp(line, "DONE:", 5) == 0) {
                             result = S_OK;
+                        } else if (strncmp(line, "STATUS:", 7) == 0) {
+                            /* Unlike the Windows --to-vhdx path there is no
+                               in-guest installer log to fall back on, so the
+                               iso-patch status lines (source squashfs, detected
+                               kernel, ingest totals, ...) are the only host-side
+                               record of how the Linux disk was built. */
+                            asb_log(L"iso-patch: %S", line + 7);
                         }
                     }
                     start = ci + 1;

--- a/tools/iso-patch/ubuntu_vhdx.c
+++ b/tools/iso-patch/ubuntu_vhdx.c
@@ -2081,6 +2081,22 @@ int do_ubuntu_to_vhdx(const wchar_t *iso_path_arg,
             goto cleanup;
         }
         strncpy(kernel_ver, pl.kernel_version, sizeof(kernel_ver) - 1);
+        if (kernel_ver[0] == 0) {
+            /* No /boot/vmlinuz-* was seen during the walk.  minimal.squashfs
+               carries the kernel on the 26.04 desktop ISO, but on 24.04 it
+               lives only in the minimal.standard.live overlay, so the rootfs
+               built here has nothing to boot.  Writing the bootstrap
+               grub.cfg with an empty version produces a disk that hangs at
+               the GRUB prompt while the UI shows "Installing Linux" forever
+               (jamesstringer90/appsandbox#66).  Fail loudly instead;
+               exit_code stays 1 so cleanup deletes the VHDX. */
+            log_err(L"no kernel (/boot/vmlinuz-*) found in %s - the disk would not boot. "
+                    L"Only Ubuntu Desktop 26.04 LTS ISOs are supported.", sqfs_path);
+            sqfs_close(sq);
+            ext4_writer_close(ew);
+            goto cleanup;
+        }
+        log_msg(L"kernel: %hs", kernel_ver);
         sqfs_close(sq);
     }
 


### PR DESCRIPTION
Refs #66 (Ubuntu 24.04 ISO hangs at "Installing Linux"). @jamesstringer90 — this doesn't add 24.04 support, it just turns the silent hang into an immediate, explained failure.

## What happens today

`do_ubuntu_to_vhdx` ingests `casper/minimal.squashfs` and takes the kernel version from the first `/boot/vmlinuz-*` seen during the walk. On the **26.04** desktop ISO that layer carries the kernel. On **24.04** it does not — the kernel lives only in the `minimal.standard.live` overlay — so `kernel_ver` stays empty and the bootstrap `grub.cfg` is written as:

```
linux  /boot/vmlinuz- root=UUID=... ro console=tty0 console=ttyS0,115200
initrd /boot/initrd.img-
```

GRUB can't load that. The guest sits at the GRUB prompt (1 vCPU at ~30 %, the other 7 at 0 %, ~24 MB of guest RAM touched, nothing on the COM1 serial pipe because the kernel never starts), the agent never connects, and the UI shows "Installing Linux" forever. Nothing in the log says why, because `run_iso_patch_ubuntu` only parses `PROGRESS:` / `ERROR:` / `DONE:` and drops iso-patch's `STATUS:` lines.

Full-ingest evidence from `ubuntu-24.04.4-desktop-amd64.iso` with this patch applied:

```
STATUS:Source squashfs: E:\casper\minimal.squashfs
STATUS:ingest: walk=0 files=85075 dirs=9287 syms=29728 special=8 errors=0 bytes=4901.4 MiB
ERROR:no kernel (/boot/vmlinuz-*) found in E:\casper\minimal.squashfs - the disk would not boot. Only Ubuntu Desktop 26.04 LTS ISOs are supported.
EXITCODE:1        (VHDX deleted by cleanup)
```

## Changes

- **`tools/iso-patch/ubuntu_vhdx.c`** — after the squashfs ingest, an empty kernel version is a hard error: `log_err()` names the image that lacked `/boot/vmlinuz-*` and states that only Ubuntu Desktop 26.04 LTS ISOs are supported; `exit_code` stays 1 so `cleanup` deletes the VHDX. On success the detected kernel is logged as a `STATUS:` line.
- **`src/backend_win/asb_core.c`** (`run_iso_patch_ubuntu`) — forward iso-patch `STATUS:` and `ERROR:` lines into the app log as `iso-patch: ...`. The Windows `--to-vhdx` path intentionally ignores `STATUS:` because the in-guest installer logs are available later; the Linux build has no such fallback, so these lines are the only host-side record of how the disk was built.

With both, a 24.04 ISO now fails the create step in ~70 s with the error surfaced in the UI log and as the create error, instead of leaving a VM that never finishes.

## Considered and dropped

A cheap pre-flight on `casper/minimal.manifest` (refuse before the ingest if no `linux-image-*` line) would have saved the ~70 s, but the manifest lists **no** `linux-image-*` package on the 26.04 and 26.04.1 ISOs either (checked via range reads against releases.ubuntu.com), so it can't discriminate. The post-ingest check reads the real squashfs contents and only rejects builds that would have been unbootable anyway — there is no path where a currently-working 26.04 build is affected.

## Testing

- Built `iso-patch.vcxproj` and `AppSandbox.sln` Release|x64 (VS 2026 Community). Only pre-existing warnings (`xz_crc64_init` in `prefetch_build_deps.c`, `DwmSetWindowAttribute` in `vm_display_idd.c`).
- `iso-patch.exe --ubuntu-to-vhdx ubuntu-24.04.4-desktop-amd64.iso --output ... --size-gb 16` (elevated): full ingest, then the new error, exit code 1, no VHDX left behind (log excerpt above).
- Reproduced the original hang on Windows 11 26200 / RTX 3070 with the same ISO before the patch: VM stuck 1.5 h at "Installing Linux" with the vCPU/memory/serial signature described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
